### PR TITLE
添加ConfigManager和QuestManager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ src/test.py
 src/chest.py
 虚拟环境创建.bat
 screenshotwhenrestart/
+venv/
+config/
+quest/
+.vscode/
+.idea/
 
 /src/ssc - 副本.png
 /src/ssc.png

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -1,0 +1,250 @@
+import os
+import json
+from utils import LoadJson, logger
+from config_vars import CONFIG_VAR_LIST
+
+GLOBAL_CONFIG_FILE_PATH = "config.json"
+GLOBAL_CONFIG_KEYS = [
+    "_KARMAADJUST",
+    "_EMUPATH",
+    "_EMUIDX",
+    "_ADBPORT",
+    "LAST_VERSION",
+    "LATEST_VERSION",
+    "LAST_CONFIG_NAME",
+]
+TASK_CONFIG_FILES_DIR = "config"
+
+
+class ConfigManager:
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super(ConfigManager, cls).__new__(cls)
+            cls._instance._initialized = False
+        return cls._instance
+
+    def __init__(self):
+        if self._initialized:
+            return
+
+        self.global_config = {}  # 存储全局配置的
+        self.current_config = {}  # 仅存储当前任务配置的
+        self.config_files = []
+
+        # 读取工作目录下的 config.json 文件
+        config_json_path = os.path.join(os.getcwd(), GLOBAL_CONFIG_FILE_PATH)
+        self.global_config = LoadJson(config_json_path)
+
+        # 获取工作目录下 config 子目录中所有 .json 文件的列表
+        self._load_config_files()
+
+        # 根据 global_config 的 last_config_name_var 读取对应的配置到 current_config
+        self._load_last_config()
+
+        self._initialized = True
+
+    def _load_last_config(self):
+        """根据 global_config 的 last_config_name_var 读取对应的配置到 current_config"""
+        last_config_name = self.global_config.get("LAST_CONFIG_NAME", "")
+
+        # 如果指定了最后使用的配置文件且存在，则加载它
+        if last_config_name and last_config_name in self.config_files:
+            self.load_config_file(last_config_name)
+        # 否则如果有配置文件，则加载第一个
+        elif self.config_files:
+            first_config_name = self.config_files[0]
+            self.load_config_file(first_config_name)
+            # 更新 global_config 中的 LAST_CONFIG_NAME
+            self.global_config["LAST_CONFIG_NAME"] = first_config_name
+            # 保存到 config.json
+            self.save_global_config()
+
+    def create_default_config_file(self, file_name="new"):
+        """以默认配置文件创建一个新的配置文件"""
+        config_dir = os.path.join(os.getcwd(), TASK_CONFIG_FILES_DIR)
+        if not os.path.exists(config_dir):
+            os.makedirs(config_dir)
+
+        # 使用CONFIG_VAR_LIST生成默认配置
+        new_config = {}
+        for attr_name, var_type, var_config_name, var_default_value in CONFIG_VAR_LIST:
+            new_config[var_config_name] = var_default_value
+
+        # 生成配置文件
+        config_file_path = os.path.join(config_dir, f"{file_name}.json")
+        result = SaveConfig(new_config, config_file_path)
+        if result:
+            logger.info(f"新配置文件 {file_name}.json 已创建。")
+        else:
+            logger.error(f"创建新配置文件 {file_name}.json 失败。")
+
+        return result
+
+    def _load_config_files(self):
+        """加载 config 子目录中的所有 .json 文件列表"""
+        config_dir = os.path.join(os.getcwd(), TASK_CONFIG_FILES_DIR)
+        if not os.path.exists(config_dir):
+            os.makedirs(config_dir)
+
+        self.config_files = []
+        if os.path.exists(config_dir):
+            for file in os.listdir(config_dir):
+                if file.endswith(".json"):
+                    self.config_files.append(os.path.splitext(file)[0])
+
+        # 如果没有任何配置文件存在
+        if not self.config_files:
+            # 照顾老用户，如果有以前的配置，则复制该配置为new，否则使用默认值生成
+            import shutil
+            src_file = os.path.join(os.getcwd(), GLOBAL_CONFIG_FILE_PATH)
+            dst_file = os.path.join(os.getcwd(), TASK_CONFIG_FILES_DIR, "new.json")
+            if os.path.exists(src_file):
+                shutil.copy(src_file, dst_file)
+                # 添加到配置文件列表
+                self.config_files.append("new")
+            else:
+                # 如果源文件不存在，使用默认值生成
+                if self.create_default_config_file("new"):
+                    # 添加到配置文件列表
+                    self.config_files.append("new")
+
+    def get_config_files(self):
+        return self.config_files
+
+    def load_config_file(self, config_name):
+        """加载指定名称的配置文件"""
+        config_file_path = os.path.join(
+            os.getcwd(), TASK_CONFIG_FILES_DIR, f"{config_name}.json"
+        )
+        if os.path.exists(config_file_path):
+            try:
+                with open(config_file_path, "r", encoding="utf-8") as f:
+                    self.current_config = json.load(f)
+                return self.current_config
+            except Exception as e:
+                logger.error(f"读取配置文件 {config_name}.json 失败: {e}")
+                return {}
+        return {}
+
+    def save_global_config(self):
+        """保存 global_config 到 config.json"""
+        config_json_path = os.path.join(os.getcwd(), GLOBAL_CONFIG_FILE_PATH)
+        result = SaveConfig(self.global_config, config_json_path)
+        if result:
+            logger.info("全局配置已保存。")
+        else:
+            logger.error("保存全局配置失败。")
+        return result
+
+    def save_current_config(self, config_name=None):
+        """保存当前配置到指定名称的文件"""
+        if not config_name:
+            config_name = self.global_config.get("LAST_CONFIG_NAME", "")
+
+        if not config_name:
+            logger.error("保存当前配置失败：未指定配置名称")
+            return False
+
+        config_file_path = os.path.join(
+            os.getcwd(), TASK_CONFIG_FILES_DIR, f"{config_name}.json"
+        )
+        result = SaveConfig(self.current_config, config_file_path)
+        if result:
+            logger.info(f"配置 {config_name} 已保存。")
+        else:
+            logger.error(f"保存配置 {config_name} 失败。")
+        return result
+
+    def save_all_configs(self, config_name=None):
+        global_saved = self.save_global_config()
+        current_saved = self.save_current_config(config_name)
+        return global_saved and current_saved
+
+    def get_combined_config(self):
+        """获取组合配置数据：GLOBAL_CONFIG_KEYS 里有的从 global 里出，没有的从 current 里出"""
+        combined_config = {}
+
+        # 首先从 current_config 中获取所有配置
+        combined_config.update(self.current_config)
+
+        # 然后用 global_config 中 GLOBAL_CONFIG_KEYS 里的配置覆盖
+        for key in GLOBAL_CONFIG_KEYS:
+            if key in self.global_config:
+                combined_config[key] = self.global_config[key]
+
+        return combined_config
+
+    def save_single_config(self, key, value):
+        """保存单个配置属性"""
+        # 判断是否是全局配置
+        if key in GLOBAL_CONFIG_KEYS:
+            self.global_config[key] = value
+            return self.save_global_config()
+        else:
+            self.current_config[key] = value
+            return self.save_current_config()
+
+    def save_config_dict(self, config_dict):
+        """保存配置字典，按 GLOBAL_CONFIG_KEYS 分配到 global 和 current"""
+        # 分离配置到 global 和 current
+        global_update = {}
+        current_update = {}
+
+        for key, value in config_dict.items():
+            if key in GLOBAL_CONFIG_KEYS:
+                global_update[key] = value
+            else:
+                current_update[key] = value
+
+        # 更新并保存
+        if global_update:
+            self.global_config.update(global_update)
+            global_saved = self.save_global_config()
+        else:
+            global_saved = True
+
+        if current_update:
+            self.current_config.update(current_update)
+            current_saved = self.save_current_config()
+        else:
+            current_saved = True
+
+        return global_saved and current_saved
+
+    def switch_config(self, config_name):
+        """切换配置文件并更新 LAST_CONFIG_NAME"""
+        if config_name in self.config_files:
+            # 加载选择的配置文件
+            self.load_config_file(config_name)
+            # 更新全局配置中的最后使用的配置名称
+            self.global_config["LAST_CONFIG_NAME"] = config_name
+            # 保存全局配置
+            return self.save_global_config()
+        return False
+
+    def get_last_config_name(self):
+        """获取当前的 LAST_CONFIG_NAME"""
+        return self.global_config.get("LAST_CONFIG_NAME", "")
+
+    def refresh_config_files(self):
+        """刷新配置文件列表并重新加载最后使用的配置"""
+        # 重新加载配置文件列表
+        self._load_config_files()
+
+        # 重新加载最后使用的配置
+        self._load_last_config()
+
+        return self.config_files
+
+
+def SaveConfig(config_data, config_file_path):
+    try:
+        with open(config_file_path, "w", encoding="utf-8") as f:
+            json.dump(config_data, f, ensure_ascii=False, indent=4)
+        return True
+    except Exception as e:
+        return False
+
+config_manager = ConfigManager()

--- a/src/config_vars.py
+++ b/src/config_vars.py
@@ -1,0 +1,33 @@
+import tkinter as tk
+from quest_manager import quest_manager
+
+
+CONFIG_VAR_LIST = [
+            #var_name,                      type,          config_name,                  default_value
+            ["farm_target_text_var",        tk.StringVar,  "_FARMTARGET_TEXT",           quest_manager.get_all_quest_codes()[0] if quest_manager.get_all_quest_codes() else ""],
+            ["farm_target_var",             tk.StringVar,  "_FARMTARGET",                ""],
+            # ["randomly_open_chest_var",     tk.BooleanVar, "_SMARTDISARMCHEST",          False],
+            ["randomly_open_chest_var",     tk.BooleanVar, "_QUICKDISARMCHEST",          False],
+            ["who_will_open_it_var",        tk.IntVar,     "_WHOWILLOPENIT",             0],
+            ["skip_recover_var",            tk.BooleanVar, "_SKIPCOMBATRECOVER",         False],
+            ["skip_chest_recover_var",      tk.BooleanVar, "_SKIPCHESTRECOVER",          False],
+            ["system_auto_combat_var",      tk.BooleanVar, "_SYSTEMAUTOCOMBAT",          False],
+            ["aoe_once_var",                tk.BooleanVar, "_AOE_ONCE",                  False],
+            ["custom_aoe_time_var",         tk.IntVar,     "_AOE_TIME",                  1],
+            ["auto_after_aoe_var",          tk.BooleanVar, "_AUTO_AFTER_AOE",            False],
+            ["active_rest_var",             tk.BooleanVar, "_ACTIVE_REST",               True],
+            ["active_royalsuite_rest_var",  tk.BooleanVar, "_ACTIVE_ROYALSUITE_REST",    False],
+            ["active_triumph_var",          tk.BooleanVar, "_ACTIVE_TRIUMPH",            False],
+            ["active_beautiful_ore_var",    tk.BooleanVar, "_ACTIVE_BEAUTIFUL_ORE",      False],
+            ["active_beg_money_var",        tk.BooleanVar, "_ACTIVE_BEG_MONEY",          True],
+            ["rest_intervel_var",           tk.IntVar,     "_RESTINTERVEL",              1],
+            ["karma_adjust_var",            tk.StringVar,  "_KARMAADJUST",               "+0"],
+            ["emu_path_var",                tk.StringVar,  "_EMUPATH",                   ""],
+            ["emu_index_var",               tk.IntVar,     "_EMUIDX",                    0],
+            ["adb_port_var",                tk.StringVar,  "_ADBPORT",                   5555],
+            ["last_version",                tk.StringVar,  "LAST_VERSION",               ""],
+            ["latest_version",              tk.StringVar,  "LATEST_VERSION",             None],
+            ["_spell_skill_config_internal",list,          "_SPELLSKILLCONFIG",          []],
+            ["active_csc_var",              tk.BooleanVar, "ACTIVE_CSC",                 True],
+            ["last_config_name_var",        str,           "LAST_CONFIG_NAME",           ""]
+            ]

--- a/src/gui.py
+++ b/src/gui.py
@@ -12,19 +12,19 @@ from quest_manager import quest_manager
 class ScrollableFrame(ttk.Frame):
     def __init__(self, container, height=None, *args, **kwargs):
         super().__init__(container, *args, **kwargs)
-        
+
         # 接收 height 参数并传递给 Canvas
         # 注意: height 单位是像素
         self.canvas = tk.Canvas(self, height=height, borderwidth=0, highlightthickness=0)
-        
+
         self.scrollbar = ttk.Scrollbar(self, orient="vertical", command=self.canvas.yview)
         self.scrollable_frame = ttk.Frame(self.canvas)
         self.canvas_frame = self.canvas.create_window((0, 0), window=self.scrollable_frame, anchor="nw")
-        
+
         self.canvas.configure(yscrollcommand=self.scrollbar.set)
         self.canvas.pack(side="left", fill="both", expand=True)
         self.scrollbar.pack(side="right", fill="y")
-        
+
         self.scrollable_frame.bind("<Configure>", self._on_frame_configure)
         self.canvas.bind("<Configure>", self._on_canvas_configure)
         self.canvas.bind_all("<MouseWheel>", self._on_mousewheel)
@@ -56,25 +56,25 @@ class CollapsibleSection(tk.Frame):
     def __init__(self, parent, title="", expanded=False,bg_color=None, *args, **kwargs):
         super().__init__(parent, *args, **kwargs)
         self.columnconfigure(0, weight=1)
-        
+
         self.is_expanded = expanded
         self.bg_color = bg_color
         self.close_emoji = "➖"
         self.showmore_emoji = "➕"
         self.config(bg=self.bg_color)
-        
+
         # 顶部标题栏
         self.header_frame = tk.Frame(self, bg=self.bg_color)
         self.header_frame.pack(fill="x", pady=2)
-        
+
         self.label = tk.Label(self.header_frame, text=title, font=("微软雅黑", 11, "bold"),bg=self.bg_color)
         self.label.pack(side="left", padx=5)
-        
+
         # 2. 根据初始状态决定图标
         icon_text = self.close_emoji if self.is_expanded else self.showmore_emoji
         self.toggle_btn = ttk.Button(self.header_frame, text=icon_text, width=3, command=self.toggle)
         self.toggle_btn.pack(side="right", padx=5)
-        
+
         self.content_frame = tk.Frame(self, bg=self.bg_color)
         self.spacer = tk.Frame(self, height=5, bg = self.bg_color)
         self.spacer.pack(fill='x')
@@ -126,7 +126,7 @@ class SkillConfigPanel(CollapsibleSection):
 
         self.custom_rows_data = []
         self.default_row_data = {}
-        
+
         # 常量
         self.ROLE_LIST = ['alice', 'bob', 'camila']
         self.SKILL_OPTIONS = ["左上技能", "右上技能", "左下技能", "右下技能", "防御", "双击自动"]
@@ -136,7 +136,7 @@ class SkillConfigPanel(CollapsibleSection):
 
         # 直接构建正文 UI
         self._setup_body_ui()
-        
+
         # 如果有初始化配置，应用它
         if init_config:
             self._apply_init_config(init_config)
@@ -147,7 +147,7 @@ class SkillConfigPanel(CollapsibleSection):
 
         btn_add = ttk.Button(action_bar, text="➕新增角色", command=self.add_custom_row, width=9.5)
         btn_add.pack(side=tk.LEFT)
-        
+
         btn_del = ttk.Button(action_bar, text="🗑删除此组", command=self.delete_panel, width=9.5)
         btn_del.pack(side=tk.RIGHT)
 
@@ -170,35 +170,35 @@ class SkillConfigPanel(CollapsibleSection):
         # 1. 设置组名
         if 'group_name' in init_config:
             self.label.config(text=init_config['group_name'])
-        
+
         # 2. 清空已有的自定义行（如果有的话）
         for row in self.custom_rows_data:
             row['frame'].destroy()
         self.custom_rows_data.clear()
-        
+
         # 3. 创建新的自定义行
         if 'skill_settings' in init_config:
             skill_settings = init_config['skill_settings']
-            
+
             for setting in skill_settings:
                 # 创建新的自定义行
                 wrapper_frame = tk.Frame(self.cards_container)
                 wrapper_frame.pack(fill=tk.X, pady=3, before=self.default_row_frame)
                 row_data = self._create_card_widget(wrapper_frame, is_default=False)
                 self.custom_rows_data.append(row_data)
-                
+
                 # 设置配置值
                 role = setting.get('role_var', '')
                 if role in self.ROLE_LIST:
                     row_data['role_var'].set(role)
                 else:
                     row_data['role_var'].set(self.ROLE_LIST[0])
-                    
+
                 row_data['skill_var'].set(setting.get('skill_var', '左上技能'))
                 row_data['target_var'].set(setting.get('target_var', '低生命值'))
                 row_data['freq_var'].set(setting.get('freq_var', '重复'))
                 row_data['lvl_var'].set(setting.get('skill_lvl', 1))
-                
+
                 # 触发技能变更检查（如果需要禁用目标选择）
                 self._on_skill_change(row_data)
 
@@ -208,14 +208,14 @@ class SkillConfigPanel(CollapsibleSection):
         """修改标题"""
         current_title = self.label.cget("text")
         new_title = simpledialog.askstring("重命名", "修改配置组名称:", initialvalue=current_title, parent=self)
-        
+
         if new_title and new_title != current_title:
             # 如果有回调函数，先调用它
             if self.on_name_change:
                 result = self.on_name_change(self, new_title)
                 if result is False:  # 如果回调返回False，认为修改失败
                     return
-            
+
             # 修改成功，更新标签
             self.label.config(text=new_title)
 
@@ -259,7 +259,7 @@ class SkillConfigPanel(CollapsibleSection):
 
         skill_cb = ttk.Combobox(row_frame, textvariable=skill_var, values=self.SKILL_OPTIONS, width=7, state="readonly")
         skill_cb.grid(row=0, column=1, padx=(0, 5), sticky=tk.W)
-        
+
         if is_default:
             skill_var.set("双击自动")
             skill_cb.config(state="disabled")
@@ -268,7 +268,7 @@ class SkillConfigPanel(CollapsibleSection):
 
         freq_cb = ttk.Combobox(row_frame, textvariable=freq_var, values=self.FREQ_OPTIONS, width=10, state="readonly")
         freq_cb.grid(row=0, column=2, sticky=tk.W)
-        
+
         if is_default:
             freq_var.set("重复")
             freq_cb.config(state="disabled")
@@ -286,7 +286,7 @@ class SkillConfigPanel(CollapsibleSection):
         tk.Label(row_frame, text="等级:", font=("微软雅黑", 9), bg=card_bg).grid(row=0, column=2, sticky=tk.E, pady=(5, 0))
         skill_lvl = ttk.Combobox(row_frame, textvariable=lvl_var, values=self.SKILL_LVL, width=5, state="readonly")
         skill_lvl.grid(row=0, column=3, sticky=tk.W, padx=(0, 5), pady=(5, 0))
-        
+
         if is_default:
             target_var.set("不可用")
             lvl_var.set(1)
@@ -300,7 +300,7 @@ class SkillConfigPanel(CollapsibleSection):
             del_btn.grid(row=0, column=4, sticky=tk.E, pady=(5, 0))
 
         row_data = {
-            'frame': parent, 
+            'frame': parent,
             'role_var': role_var,
             'skill_var': skill_var, 'skill_widget': skill_cb,
             'target_var': target_var, 'target_widget': target_cb,
@@ -336,7 +336,7 @@ class SkillConfigPanel(CollapsibleSection):
     def get_config_list(self):
         """获取当前配置，返回指定格式的字典（只包含自定义行）"""
         skill_settings = []
-        
+
         # 只添加自定义行，不包含默认行
         for row in self.custom_rows_data:
             item = {
@@ -347,7 +347,7 @@ class SkillConfigPanel(CollapsibleSection):
                 'skill_lvl': row['lvl_var'].get()  # 添加技能等级
             }
             skill_settings.append(item)
-        
+
         # 返回指定格式，不包含默认行
         return {
             'group_name': self.label.cget("text"),
@@ -367,7 +367,7 @@ class ConfigPanelApp(tk.Toplevel):
         self.controller = master_controller
         self.msg_queue = msg_queue
         self.geometry('610x750')
-        
+
         self.title(self.TITLE)
 
         self.adb_active = False
@@ -389,13 +389,13 @@ class ConfigPanelApp(tk.Toplevel):
 
         # --- UI 变量 ---
         self.load_config(is_init=True)
-        
+
         for btn,_,spellskillList,_,_ in SPELLSEKILL_TABLE:
             for item in spellskillList:
                 if item not in self._spell_skill_config_internal:
                     setattr(self,f"{btn}_var",tk.BooleanVar(value = False))
                     break
-                setattr(self,f"{btn}_var",tk.BooleanVar(value = True))             
+                setattr(self,f"{btn}_var",tk.BooleanVar(value = True))
 
         self.create_widgets()
         self.update_system_auto_combat()
@@ -411,7 +411,7 @@ class ConfigPanelApp(tk.Toplevel):
         logger.info(f"当前版本: {version}")
         logger.info(self.INTRODUCTION, extra={"summary": True})
         logger.info("**********************************")
-        
+
         if self.last_version.get() != version:
             ShowChangesLogWindow()
             self.last_version.set(version)
@@ -436,7 +436,7 @@ class ConfigPanelApp(tk.Toplevel):
                 else:
                     setattr(self, attr_name, var_type(self.config.get(var_config_name,var_default_value)))
             self.update_widgets_values()
-    
+
     def update_widgets_values(self):
         """更新无法自动更新值的控件"""
         # 更新配置选择器，这个主要是防止刷新目录后有选项消失
@@ -478,7 +478,7 @@ class ConfigPanelApp(tk.Toplevel):
         else:
             self.farm_target_var.set(None)
             self.config["_FARMTARGET"] = ""
-        
+
         self.config["LAST_CONFIG_NAME"] = config_manager.get_last_config_name()
 
         # 使用config_manager保存配置
@@ -518,7 +518,7 @@ class ConfigPanelApp(tk.Toplevel):
         self.main_frame = ttk.Frame(self, padding="10")
         self.main_frame.grid(row=0, column=0, sticky=(tk.W, tk.E, tk.N, tk.S))
 
-        self.main_frame.rowconfigure(0, weight=1) 
+        self.main_frame.rowconfigure(0, weight=1)
         self.main_frame.columnconfigure(0, weight=1)
 
         self.scroll_view = ScrollableFrame(self.main_frame, height=620)
@@ -530,21 +530,21 @@ class ConfigPanelApp(tk.Toplevel):
         # ==========================================
         self.section_emu = CollapsibleSection(content_root, title="模拟器", expanded= False if self.emu_path_var.get() else True,)
         self.section_emu.pack(fill="x", pady=(0, 5)) # 使用pack垂直堆叠
-        
+
         # 获取折叠板的内容容器
-        container = self.section_emu.content_frame 
+        container = self.section_emu.content_frame
 
         # --- 原有逻辑 (微调父容器为 container) ---
-        row_counter = 0 
+        row_counter = 0
         frame_row = ttk.Frame(container)
         frame_row.grid(row=row_counter, column=0, sticky="ew", pady=2)
-        
+
         self.adb_status_label = ttk.Label(frame_row)
         self.adb_status_label.grid(row=0, column=0)
-        
+
         adb_entry = ttk.Entry(frame_row, textvariable=self.emu_path_var)
         adb_entry.grid_remove()
-        
+
         def selectADB_PATH():
             path = filedialog.askopenfilename(
                 title="选择ADB执行文件",
@@ -558,13 +558,13 @@ class ConfigPanelApp(tk.Toplevel):
             frame_row, text="修改", command=selectADB_PATH, width=5
         )
         self.adb_path_change_button.grid(row=0, column=1)
-        
+
         def update_adb_status(*args):
             if self.emu_path_var.get():
                 self.adb_status_label.config(text="已设置模拟器", foreground="green")
             else:
                 self.adb_status_label.config(text="未设置模拟器", foreground="red")
-        
+
         self.emu_path_var.trace_add("write", lambda *args: update_adb_status())
         update_adb_status()
 
@@ -595,7 +595,7 @@ class ConfigPanelApp(tk.Toplevel):
 
         # 配置选择
         config_files = config_manager.get_config_files()
-        
+
         frame_row = ttk.Frame(container)
         frame_row.grid(row=row_counter, column=0, sticky="ew", pady=2)
         ttk.Label(frame_row, text="配置:").grid(row=0, column=0, sticky=tk.W, pady=5)
@@ -611,12 +611,12 @@ class ConfigPanelApp(tk.Toplevel):
                 if config_manager.switch_config(config_name):
                     # 重新加载配置到UI
                     self.load_config()
-        
+
         # 当选择配置时，加载对应的配置文件
         def on_config_selected(event):
             selected_config_name = self.config_combo.get()
             handle_config_change(selected_config_name)
-        
+
         self.config_combo.bind("<<ComboboxSelected>>", on_config_selected)
 
         # 刷新按钮
@@ -628,10 +628,10 @@ class ConfigPanelApp(tk.Toplevel):
             # 设置默认选择的配置为最后使用的配置
             last_config_name = config_manager.get_last_config_name()
             handle_config_change(last_config_name)
-        
+
         self.refresh_button = ttk.Button(frame_row, text="刷新", command=refresh_configs, width=5)
         self.refresh_button.grid(row=0, column=2, sticky=tk.W, pady=5, padx=5)
-        
+
         # 打开文件夹按钮
         def open_config_folder():
             import os
@@ -639,17 +639,17 @@ class ConfigPanelApp(tk.Toplevel):
             if not os.path.exists(config_dir):
                 os.makedirs(config_dir)
             os.startfile(config_dir)
-        
+
         self.open_folder_button = ttk.Button(frame_row, text="文件夹", command=open_config_folder, width=6)
         self.open_folder_button.grid(row=0, column=3, sticky=tk.W, pady=5, padx=5)
-                
+
         row_counter += 1
 
         # 地下城目标
         frame_row = ttk.Frame(container)
         frame_row.grid(row=row_counter, column=0, sticky="ew", pady=2)
         ttk.Label(frame_row, text="任务目标:").grid(row=0, column=0, sticky=tk.W, pady=5)
-        self.farm_target_combo = ttk.Combobox(frame_row, textvariable=self.farm_target_text_var, 
+        self.farm_target_combo = ttk.Combobox(frame_row, textvariable=self.farm_target_text_var,
                                               values=quest_manager.get_all_quest_names(), state="readonly")
         self.farm_target_combo.grid(row=0, column=1, sticky=(tk.W, tk.E), pady=5)
         self.farm_target_combo.bind("<<ComboboxSelected>>", lambda e: self.save_config())
@@ -667,12 +667,12 @@ class ConfigPanelApp(tk.Toplevel):
         row_counter += 1
         frame_row = ttk.Frame(container)
         frame_row.grid(row=row_counter, column=0, sticky="ew", pady=2)
-        
+
         ttk.Label(frame_row, text="开箱人选:").grid(row=0, column=0, sticky=tk.W, pady=5)
 
         self.open_chest_mapping = {0:"随机", 1:"左上", 2:"中上", 3:"右上", 4:"左下", 5:"中下", 6:"右下"}
         self.who_will_open_text_var = tk.StringVar(value=self.open_chest_mapping.get(self.who_will_open_it_var.get(), "随机"))
-        self.who_will_open_combobox = ttk.Combobox(frame_row, textvariable=self.who_will_open_text_var, 
+        self.who_will_open_combobox = ttk.Combobox(frame_row, textvariable=self.who_will_open_text_var,
                                                    values=list(self.open_chest_mapping.values()), state="readonly", width=4)
         self.who_will_open_combobox.grid(row=0, column=1, sticky=tk.W, pady=5)
         def handle_open_chest_selection(event=None):
@@ -721,18 +721,18 @@ class ConfigPanelApp(tk.Toplevel):
         frame_row = ttk.Frame(container)
         frame_row.grid(row=row_counter, column=0, sticky="ew", pady=2)
         ttk.Label(frame_row, text=f"善恶:").grid(row=0, column=0, sticky=tk.W, pady=5)
-        
+
         # 善恶值逻辑保持不变
         self.karma_adjust_mapping = {"维持现状": "+0", "恶→中立,中立→善": "+17", "善→中立,中立→恶": "-17"}
         times = int(self.karma_adjust_var.get())
         if times == 0: self.karma_adjust_text_var = tk.StringVar(value="维持现状")
         elif times > 0: self.karma_adjust_text_var = tk.StringVar(value="恶→中立,中立→善")
         elif times < 0: self.karma_adjust_text_var = tk.StringVar(value="善→中立,中立→恶")
-            
+
         self.karma_adjust_combobox = ttk.Combobox(frame_row, textvariable=self.karma_adjust_text_var,
                                                   values=list(self.karma_adjust_mapping.keys()), state="readonly", width=14)
         self.karma_adjust_combobox.grid(row=0, column=1, sticky=tk.W, pady=5)
-        
+
         def handle_karma_adjust_selection(event=None):
             karma_adjust_left = int(self.karma_adjust_var.get())
             karma_adjust_want = int(self.karma_adjust_mapping[self.karma_adjust_text_var.get()])
@@ -741,7 +741,7 @@ class ConfigPanelApp(tk.Toplevel):
             self.karma_adjust_var.set(self.karma_adjust_mapping[self.karma_adjust_text_var.get()])
             self.save_config()
         self.karma_adjust_combobox.bind("<<ComboboxSelected>>", handle_karma_adjust_selection)
-        
+
         ttk.Label(frame_row, text="还需").grid(row=0, column=2, sticky=tk.W, pady=5)
         ttk.Label(frame_row, textvariable=self.karma_adjust_var).grid(row=0, column=3, sticky=tk.W, pady=5)
         ttk.Label(frame_row, text="点").grid(row=0, column=4, sticky=tk.W, pady=5)
@@ -768,7 +768,7 @@ class ConfigPanelApp(tk.Toplevel):
                 if self.btn_enable_secret_aoe_var.get() != True: self.btn_enable_secret_aoe.invoke()
             self.update_change_aoe_once_check()
             self.save_config()
-            
+
         frame_row = ttk.Frame(container)
         frame_row.grid(row=row_counter, column=0, sticky="ew", pady=2)
         self.aoe_once_check = ttk.Checkbutton(frame_row, text="一场战斗中仅释放", variable=self.aoe_once_var,
@@ -792,7 +792,7 @@ class ConfigPanelApp(tk.Toplevel):
         row_counter += 1
         self.skills_button_frame = ttk.Frame(container)
         self.skills_button_frame.grid(row=row_counter, column=0, columnspan=2, sticky=tk.W)
-        
+
         for buttonName, buttonText, buttonSpell, s_row, s_col in SPELLSEKILL_TABLE:
             setattr(self, buttonName, ttk.Checkbutton(
                 self.skills_button_frame,
@@ -818,10 +818,10 @@ class ConfigPanelApp(tk.Toplevel):
         #     # 从字典中删除该panel
         #     if p in self.skill_configs:
         #         del self.skill_configs[p]
-            
+
         #     # 销毁面板
         #     p.destroy()
-            
+
         #     # 如果没有面板了，隐藏容器
         #     if len(self.skill_configs) == 0:
         #         self.panels_container.grid_forget()
@@ -832,11 +832,11 @@ class ConfigPanelApp(tk.Toplevel):
         #     if new_name in self.skill_configs.values() and new_name != self.skill_configs.get(panel):
         #         messagebox.showerror("错误", f"名称 '{new_name}' 已存在，请使用其他名称")
         #         return False
-            
+
         #     # 更新映射
         #     self.skill_configs[panel] = new_name
         #     return True
-        
+
         # def get_all_configs():
         #     """获取所有面板的配置"""
         #     all_configs = []
@@ -844,7 +844,7 @@ class ConfigPanelApp(tk.Toplevel):
         #         config = panel.get_config_list()
         #         all_configs.append(config)
         #     return all_configs
-                
+
         # def add_new_panel():
         #     self.panels_container.grid()
 
@@ -864,7 +864,7 @@ class ConfigPanelApp(tk.Toplevel):
         #         init_config=None,
         #     )
         #     panel.pack(fill=tk.X, pady=2)
-            
+
         #     # 将panel和名称添加到映射中
         #     self.skill_configs[panel] = title
 
@@ -883,7 +883,7 @@ class ConfigPanelApp(tk.Toplevel):
         # ==========================================
         self.section_advanced = CollapsibleSection(content_root, title="高级")
         self.section_advanced.pack(fill="x", pady=5)
-        
+
         # 获取容器
         container = self.section_advanced.content_frame
         row_counter = 0
@@ -951,7 +951,7 @@ class ConfigPanelApp(tk.Toplevel):
             style="Custom.TCheckbutton"
         )
         self.active_csc.grid(row=0, column=0, sticky=tk.W)
-        
+
         # 分割线
         self.columnconfigure(0, weight=1)
         self.rowconfigure(1, weight=1)
@@ -1066,10 +1066,10 @@ class ConfigPanelApp(tk.Toplevel):
                 for buttonName,buttonText,buttonSpell, row, col in SPELLSEKILL_TABLE:
                     if getattr(self,f"{buttonName}_var").get():
                         self._spell_skill_config_internal += buttonSpell
-        
+
         # 更新按钮颜色
         self.update_system_auto_combat_state()
-    
+
         # 保存
         self.save_config()
 
@@ -1146,7 +1146,10 @@ class ConfigPanelApp(tk.Toplevel):
             self.active_royalsuite_rest,
             self.active_beg_money,
             self.button_save_adb_port,
-            self.active_csc
+            self.active_csc,
+            self.config_combo,
+            self.refresh_button,
+            self.open_folder_button
             ]
 
         if state == tk.DISABLED:

--- a/src/quest_manager.py
+++ b/src/quest_manager.py
@@ -1,0 +1,145 @@
+import json
+import os
+from utils import LoadJson, ResourcePath
+
+QUEST_FILE = 'resources/quest/quest.json'
+
+class QuestManager:
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super(QuestManager, cls).__new__(cls)
+            cls._instance._initialized = False
+        return cls._instance
+
+    def __init__(self):
+        if self._initialized:
+            return
+       
+        self.reload_quest_data()
+        self._initialized = True
+
+    def reload_quest_data(self):
+        self._quest_reflect_map = {}
+        self._quest_data = {}
+        self._error_logs = []
+        self._load_builtin_quest_data()
+        self._load_custom_quest_data()
+
+    def _load_builtin_quest_data(self):
+        """读取内置任务数据"""
+        try:
+            data = LoadJson(ResourcePath(QUEST_FILE))
+            
+            seen_names = set(self._quest_reflect_map.keys())
+            
+            for quest_code, quest_info in data.items():
+                if "questName" not in quest_info:
+                    error_msg = f"★　内置任务代码 '{quest_code}' 缺少 'questName' 属性"
+                    self._error_logs.append(error_msg)
+                    continue
+                
+                quest_name = quest_info["questName"]
+                
+                # 检查任务代码是否重复
+                if quest_code in self._quest_data:
+                    error_msg = f"★　内置任务数据发现重复的任务代码: '{quest_code}'"
+                    self._error_logs.append(error_msg)
+                    continue
+                
+                # 检查名称是否重复
+                if quest_name in seen_names:
+                    error_msg = f"★　内置任务数据发现重复的任务名称: '{quest_name}'，已有的任务代码 '{self._quest_reflect_map[quest_name]}'，当前出错任务代码 '{quest_code}'"
+                    self._error_logs.append(error_msg)
+                    continue
+                
+                # 添加数据
+                self._quest_reflect_map[quest_name] = quest_code
+                seen_names.add(quest_name)
+                self._quest_data[quest_code] = quest_info
+
+        except json.JSONDecodeError as e:
+            error_msg = f"内置任务数据 JSON 解析错误，第 {e.lineno} 行，第 {e.colno} 列: {e.msg}"
+            self._error_logs.append(error_msg)
+        except FileNotFoundError as e:
+            error_msg = f"内置任务数据文件未找到: {e}"
+            self._error_logs.append(error_msg)
+
+    def _load_custom_quest_data(self):
+        """读取自定义任务数据"""
+        try:
+            custom_quest_dir = os.path.join(os.getcwd(), "quest")
+            if not os.path.exists(custom_quest_dir):
+                os.makedirs(custom_quest_dir)
+                return
+            
+            seen_names = set(self._quest_reflect_map.keys())
+            
+            # 遍历quest目录下的所有json文件
+            for file_name in os.listdir(custom_quest_dir):
+                if file_name.endswith(".json"):
+                    file_path = os.path.join(custom_quest_dir, file_name)
+                    try:
+                        data = LoadJson(file_path)
+                        
+                        for quest_code, quest_info in data.items():
+                            if "questName" not in quest_info:
+                                error_msg = f"★　自定义任务文件 '{file_name}' 中的任务代码 '{quest_code}' 缺少 'questName' 属性"
+                                self._error_logs.append(error_msg)
+                                continue
+                            
+                            quest_name = quest_info["questName"]
+                            
+                            # 检查任务代码是否重复
+                            if quest_code in self._quest_data:
+                                error_msg = f"★　自定义任务文件 '{file_name}' 中发现重复的任务代码: '{quest_code}'"
+                                self._error_logs.append(error_msg)
+                                continue
+                            
+                            if quest_name in seen_names:
+                                error_msg = f"★　自定义任务文件 '{file_name}' 中发现重复的任务名称: '{quest_name}'，已有的任务代码 '{self._quest_reflect_map[quest_name]}'，当前出错任务代码 '{quest_code}'"
+                                self._error_logs.append(error_msg)
+                                continue
+                            
+                            self._quest_reflect_map[quest_name] = quest_code
+                            seen_names.add(quest_name)
+                            self._quest_data[quest_code] = quest_info
+                    except json.JSONDecodeError as e:
+                        error_msg = f"自定义任务文件 '{file_name}' JSON解析错误，第 {e.lineno} 行，第 {e.colno} 列: {e.msg}"
+                        self._error_logs.append(error_msg)
+                    except Exception as e:
+                        error_msg = f"读取自定义任务文件 '{file_name}' 时出错: {str(e)}"
+                        self._error_logs.append(error_msg)
+        except Exception as e:
+            error_msg = f"读取自定义任务数据时出错: {str(e)}"
+            self._error_logs.append(error_msg)
+
+    def get_quest_map(self):
+        """获取任务名称到任务代码的映射表"""
+        return self._quest_reflect_map
+
+    def get_error_logs(self):
+        """获取加载时的错误日志列表"""
+        return self._error_logs
+
+    def get_all_quest_codes(self):
+        """获取所有任务代码列表"""
+        return list(self._quest_data.keys())
+
+    def get_all_quest_names(self):
+        """获取所有任务名称列表"""
+        return list(self._quest_reflect_map.keys())
+    
+    def get_quest_by_name(self, quest_name):
+        """根据任务名称获取任务数据"""
+        quest_code = self._quest_reflect_map.get(quest_name, None)
+        if quest_code:
+            return self._quest_data.get(quest_code, None)
+        return None
+
+    def get_quest_by_code(self, quest_code):
+        """根据任务代码获取任务数据"""
+        return self._quest_data.get(quest_code, None)
+
+quest_manager = QuestManager()

--- a/src/script.py
+++ b/src/script.py
@@ -9,7 +9,7 @@ import subprocess
 from utils import *
 from config_manager import config_manager
 from config_vars import CONFIG_VAR_LIST
-from quest_manager import QuestManager
+from quest_manager import quest_manager
 import random
 
 from threading import Thread,Event
@@ -118,7 +118,7 @@ class TargetInfo:
                 value = [[100,1200,700,250]]
             case _:
                 value = inputValue
-        
+
         self._swipeDir = value
 
     @property
@@ -151,7 +151,7 @@ def GetADBPathFromEmuPath(emu_path):
         if not os.path.exists(adb_path):
             logger.error(f"adb程序序不存在: {adb_path}")
             return None
-    
+
         return adb_path
 
 def CheckAndRecoverDevice(setting : FarmConfig, runtimeContext: RuntimeContext, FORCE_RESTART_EMU = False, FORCE_RESTART_ADB = False):
@@ -159,7 +159,7 @@ def CheckAndRecoverDevice(setting : FarmConfig, runtimeContext: RuntimeContext, 
         result = subprocess.run(
             'tasklist /FO CSV /NH | findstr "MuMuNxDevice.exe MuMuPlayer.exe"',
             shell=True,
-            capture_output=True, 
+            capture_output=True,
             text=True
         )
         result_str = result.stdout.strip()
@@ -173,7 +173,7 @@ def CheckAndRecoverDevice(setting : FarmConfig, runtimeContext: RuntimeContext, 
             # Windows 系统使用 taskkill 命令
             if os.name == 'nt':
                 subprocess.run(
-                    f"taskkill /f /im adb.exe", 
+                    f"taskkill /f /im adb.exe",
                     shell=True,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
@@ -181,7 +181,7 @@ def CheckAndRecoverDevice(setting : FarmConfig, runtimeContext: RuntimeContext, 
                 )
                 time.sleep(1)
                 subprocess.run(
-                    f"taskkill /f /im HD-Adb.exe", 
+                    f"taskkill /f /im HD-Adb.exe",
                     shell=True,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
@@ -189,7 +189,7 @@ def CheckAndRecoverDevice(setting : FarmConfig, runtimeContext: RuntimeContext, 
                 )
             else:
                 subprocess.run(
-                    f"pkill -f {adb_path}", 
+                    f"pkill -f {adb_path}",
                     shell=True,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
@@ -208,7 +208,7 @@ def CheckAndRecoverDevice(setting : FarmConfig, runtimeContext: RuntimeContext, 
                 if runtimeContext._RUNNING_EMU_PID:
                     logger.info(f"使用已知进程号{runtimeContext._RUNNING_EMU_PID}关闭模拟器...")
                     subprocess.run(
-                        f"taskkill /f /pid {runtimeContext._RUNNING_EMU_PID}", 
+                        f"taskkill /f /pid {runtimeContext._RUNNING_EMU_PID}",
                         shell=True,
                         stdout=subprocess.DEVNULL,
                         stderr=subprocess.DEVNULL,
@@ -218,7 +218,7 @@ def CheckAndRecoverDevice(setting : FarmConfig, runtimeContext: RuntimeContext, 
                 else:
                     logger.info(f"模拟器uid未知, 全杀了.")
                     subprocess.run(
-                        f"taskkill /f /im {emulator_name}", 
+                        f"taskkill /f /im {emulator_name}",
                         shell=True,
                         stdout=subprocess.DEVNULL,
                         stderr=subprocess.DEVNULL,
@@ -226,7 +226,7 @@ def CheckAndRecoverDevice(setting : FarmConfig, runtimeContext: RuntimeContext, 
                     )
                     time.sleep(1)
                     subprocess.run(
-                        f"taskkill /f /im {emulator_SVC}", 
+                        f"taskkill /f /im {emulator_SVC}",
                         shell=True,
                         stdout=subprocess.DEVNULL,
                         stderr=subprocess.DEVNULL,
@@ -237,14 +237,14 @@ def CheckAndRecoverDevice(setting : FarmConfig, runtimeContext: RuntimeContext, 
             # Unix/Linux 系统使用 pkill 命令
             else:
                 subprocess.run(
-                    f"pkill -f {emulator_name}", 
+                    f"pkill -f {emulator_name}",
                     shell=True,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
                     check=False
                 )
                 subprocess.run(
-                    f"pkill -f {emulator_headless}", 
+                    f"pkill -f {emulator_headless}",
                     shell=True,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
@@ -262,7 +262,7 @@ def CheckAndRecoverDevice(setting : FarmConfig, runtimeContext: RuntimeContext, 
         if not os.path.exists(hd_player_path):
             logger.error(f"模拟器启动程序不存在: {hd_player_path}")
             return False
-        
+
         cmd = f'"{hd_player_path}" control -v {setting._EMUIDX}'
         try:
             logger.info(f"启动模拟器: {cmd}")
@@ -271,9 +271,9 @@ def CheckAndRecoverDevice(setting : FarmConfig, runtimeContext: RuntimeContext, 
             pre_result_list = CheckEmulator()
 
             subprocess.Popen(
-                cmd, 
+                cmd,
                 shell=True,
-                stdout=subprocess.DEVNULL, 
+                stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 cwd=os.path.dirname(hd_player_path))
 
@@ -293,7 +293,7 @@ def CheckAndRecoverDevice(setting : FarmConfig, runtimeContext: RuntimeContext, 
         except Exception as e:
             logger.error(f"启动模拟器失败: {str(e)}")
             return False
-        
+
         logger.info("等待模拟器启动...")
         time.sleep(15)
 
@@ -304,7 +304,7 @@ def CheckAndRecoverDevice(setting : FarmConfig, runtimeContext: RuntimeContext, 
     if FORCE_RESTART_EMU:
         KillEmulator()
         time.sleep(1)
-    
+
     if FORCE_RESTART_ADB:
         KillAdb()
         time.sleep(1)
@@ -321,7 +321,7 @@ def CheckAndRecoverDevice(setting : FarmConfig, runtimeContext: RuntimeContext, 
             KillAdb()
 
             # 我们不起手就关, 但是如果2次链接还是尝试失败, 那就触发一次强制重启.
-        
+
         try:
             logger.info("检查adb服务...")
             result = CMDLine(f"\"{adb_path}\" devices")
@@ -378,7 +378,7 @@ def CheckAndRecoverDevice(setting : FarmConfig, runtimeContext: RuntimeContext, 
     try:
         client = AdbClient(host="127.0.0.1", port=5037)
         devices = client.devices()
-        
+
         # 查找匹配的设备
         target_device = f"127.0.0.1:{setting._ADBPORT}"
         for device in devices:
@@ -387,7 +387,7 @@ def CheckAndRecoverDevice(setting : FarmConfig, runtimeContext: RuntimeContext, 
                 return device
     except Exception as e:
         logger.error(f"创建ADB设备时出错: {e}")
-    
+
     return None
 ##################################################################
 def CutRoI(screenshot,roi):
@@ -439,12 +439,11 @@ def Factory():
     runtimeContext = None
     def LoadQuest():
         # 构建文件路径
-        questManager = QuestManager()
-        data = questManager.get_quest_by_code(setting._FARMTARGET)
+        data = quest_manager.get_quest_by_code(setting._FARMTARGET)
         if data is None:
             logger.error("任务列表已更新.请重新手动选择地下城任务.")
             return
-        
+
         # 创建 Quest 实例并填充属性
         quest = FarmQuest()
         for key, value in data.items():
@@ -456,7 +455,7 @@ def Factory():
                 pass
             else:
                 logger.info(f"'{key}'并不存在于FarmQuest中.")
-        
+
         if 'extraConfig' in data and isinstance(data['extraConfig'], dict):
             for key, value in data['extraConfig'].items():
                 if hasattr(setting, key):
@@ -477,7 +476,7 @@ def Factory():
             exception = None
             result = None
             completed = Event()
-            
+
             def adb_command_thread():
                 nonlocal exception, result
                 try:
@@ -486,20 +485,20 @@ def Factory():
                     exception = e
                 finally:
                     completed.set()
-            
+
             thread = Thread(target=adb_command_thread)
             thread.daemon = True
             thread.start()
-            
+
             try:
                 if not completed.wait(timeout=7):
                     # 线程超时未完成
                     logger.warning(f"ADB命令执行超时: {cmdStr}")
                     raise TimeoutError(f"ADB命令在{7}秒内未完成")
-                
+
                 if exception is not None:
                     raise exception
-                    
+
                 return result
             except ( RuntimeError, ConnectionResetError, cv2.error) as e:
                 logger.warning(f"ADB操作失败 ({type(e).__name__}): {e}")
@@ -509,7 +508,7 @@ def Factory():
 
                 continue
             except TimeoutError as e:
-                logger.info("ADB超时, 尝试重启ADB或模拟器程序...")             
+                logger.info("ADB超时, 尝试重启ADB或模拟器程序...")
                 ResetDevice(force_restart_adb=True)
                 time.sleep(1)
 
@@ -518,14 +517,14 @@ def Factory():
                 # 非预期异常直接抛出
                 logger.error(f"非预期的ADB异常: {type(e).__name__}: {e}")
                 raise
-    
+
     def Sleep(t=1):
         time.sleep(t)
     def ScreenShot():
         t = time.time()
         # 获取设备序列号，用于构造 adb 命令
-        serial = setting._ADBDEVICE.serial 
-        
+        serial = setting._ADBDEVICE.serial
+
         while True:
             try:
                 process_result = subprocess.run(
@@ -533,18 +532,18 @@ def Factory():
                     capture_output=True, # 捕获输出
                     timeout=5            # 设置超时
                 )
-                
+
                 if process_result.stderr:
                     logger.error(f"截图命令报错: {process_result.stderr.decode('utf-8', errors='ignore')}")
                     raise RuntimeError("截图命令报错")
 
                 raw_data = process_result.stdout
-                
+
                 # 解析头部信息 (前12个字节)
                 if len(raw_data) < 12:
                     logger.error("截图数据不足12字节(无头信息)")
                     raise RuntimeError("截图数据异常")
-                
+
                 # struct.unpack 解析二进制: '<'小端序, 'I'无符号整型(4字节)
                 # 前三个整数分别是: 宽度, 高度, 像素格式
                 w, h, fmt = struct.unpack("<III", raw_data[:12])
@@ -566,10 +565,10 @@ def Factory():
 
                 # 注意：现在的 image.shape 已经是 (h, w, 3)
                 current_h, current_w = image.shape[:2]
-               
+
                 if (current_h, current_w) != (1600, 900):
                     if (current_h, current_w) == (900, 1600):
-                        logger.error(f"截图尺寸错误: 当前{image.shape}, 检测为横屏.")                        
+                        logger.error(f"截图尺寸错误: 当前{image.shape}, 检测为横屏.")
                         restartGame(skipScreenShot=True)
                     else:
                         logger.error(f"截图尺寸错误: 期望(1600,900), 实际({current_h},{current_w}).")
@@ -583,7 +582,7 @@ def Factory():
                 logger.warning("截图超时 (Subprocess)")
                 logger.info("ADB操作失败, 尝试重启ADB或模拟器程序...")
                 ResetDevice(force_restart_adb=True)
-                
+
             except Exception as e:
                 logger.debug(f"截图发生异常: {e}")
                 if isinstance(e, (AttributeError, RuntimeError, ConnectionResetError, cv2.error)):
@@ -684,7 +683,7 @@ def Factory():
 
         for i in range(4):
             template = LoadTemplateImage(f"cursor_{i}")
-        
+
             result = cv2.matchTemplate(cropped, template, cv2.TM_CCOEFF_NORMED)
             threshold = 0.80
             _, max_val, _, _ = cv2.minMaxLoc(result)
@@ -692,14 +691,14 @@ def Factory():
             logger.debug(f"目标格搜素{position}, 匹配程度:{max_val*100:.2f}%")
             if max_val > threshold:
                 logger.debug("已达到检测阈值.")
-                return None 
+                return None
         return position
     def CheckIf_throughStair(screenImage,targetInfo : TargetInfo):
         stair_img = ["stair_up","stair_down","stair_teleport"]
         screenshot = screenImage
         position = targetInfo.roi
         cropped = screenshot[position[1]-33:position[1]+33, position[0]-33:position[0]+33]
-        
+
         if (targetInfo.target not in stair_img):
             # 验证楼层
             template = LoadTemplateImage(targetInfo.target)
@@ -712,7 +711,7 @@ def Factory():
                 logger.info("楼层正确, 判定为已通过")
                 return None
             return position
-            
+
         else: #equal: targetInfo.target IN stair_img
             template = LoadTemplateImage(targetInfo.target)
             result = cv2.matchTemplate(cropped, template, cv2.TM_CCOEFF_NORMED)
@@ -729,7 +728,7 @@ def Factory():
         template =  LoadTemplateImage(f"fastforward_off")
         screenshot =  screenImage
         cropped = screenshot[position[1]-50:position[1]+50, position[0]-50:position[0]+50]
-        
+
         result = cv2.matchTemplate(cropped, template, cv2.TM_CCOEFF_NORMED)
         _, max_val, _, max_loc = cv2.minMaxLoc(result)
         threshold = 0.80
@@ -762,7 +761,7 @@ def Factory():
         nonlocal runtimeContext
         if runtimeContext._IMPORTANTINFO == "":
             runtimeContext._IMPORTANTINFO = "👆向上滑动查看重要信息👆\n"
-        time_str = datetime.now().strftime("%Y%m%d-%H%M%S") 
+        time_str = datetime.now().strftime("%Y%m%d-%H%M%S")
         runtimeContext._IMPORTANTINFO = f"{time_str} {str}\n{runtimeContext._IMPORTANTINFO}"
     ##################################################################
     def FindCoordsOrElseExecuteFallbackAndWait(targetPattern, fallback,waitTime):
@@ -799,7 +798,7 @@ def Factory():
                 if Press(CheckIf_fastForwardOff(scn)):
                     Sleep(1)
                     continue
-                
+
                 if fallback: # Execute
                     if isinstance(fallback, (list, tuple)):
                         if (len(fallback) == 2) and all(isinstance(x, (int, float)) for x in fallback):
@@ -1043,17 +1042,17 @@ def Factory():
     def TeleportFromCityToWorldLocation(target, swipe, press_any_key = [550,1]):
         nonlocal runtimeContext
         FindCoordsOrElseExecuteFallbackAndWait(['intoWorldMap','dungFlag','worldmapflag','openworldmap','startdownload'],['closePartyInfo','closePartyInfo_fortress',[550,1]],1)
-        
+
         if CheckIf(scn:=ScreenShot(), 'dungflag'):
             # 如果已经在副本里了 直接结束.
             # 因为该函数预设了是从城市开始的.
             return
-        
+
         if CheckIf(scn, 'openworldmap'):
             # 如果已经进入了洞窟, 直接结束.
             # 因为这是无战斗无宝箱然后重新尝试的情况.
             return
-        
+
         if Press(CheckIf(scn,'intoWorldMap')):
             # 如果在城市, 尝试进入世界地图
             Sleep(0.5)
@@ -1077,7 +1076,7 @@ def Factory():
         Press(pos)
         Sleep(1)
         FindCoordsOrElseExecuteFallbackAndWait(['Inn','openworldmap','dungFlag'],[target,press_any_key],1)
-    
+
     def TeleportFromDungeonToCity(target, swipe, press_any_key = [550,1]):
         nonlocal runtimeContext
         FindCoordsOrElseExecuteFallbackAndWait(['dungFlag','worldmapflag','openworldmap','startdownload'],'openworldmap',1)
@@ -1104,7 +1103,7 @@ def Factory():
         Press(pos)
         Sleep(1)
         FindCoordsOrElseExecuteFallbackAndWait(['Inn','openworldmap','dungFlag'],[target,press_any_key],1)
-        
+
     def CursedWheelTimeLeap(target="GhostsOfYore", CSC_symbol=None,CSC_setting = None, chapter = 'cursedwheel_impregnableFortress'):
         # CSC_symbol: 是否开启因果? 如果开启因果, 将用这个作为是否点开ui的检查标识
         # CSC_setting: 默认会先选择不接所有任务. 这个列表中储存的是想要打开的因果.
@@ -1201,7 +1200,7 @@ def Factory():
             for pattern, state in identifyConfig:
                 if CheckIf(screen, pattern):
                     return State.Dungeon, state, screen
-                
+
             if StateCombatCheck(screen):
                 return State.Dungeon, DungeonState.Combat, screen
 
@@ -1250,7 +1249,7 @@ def Factory():
                 for symbol in quest._SPECIALFORCESTOPINGSYMBOL:
                         if CheckIf(screen,symbol):
                             return State.Quit,DungeonState.Quit,screen
-                        
+
             if quest._SPECIALDIALOGOPTION != None:
                 for option in quest._SPECIALDIALOGOPTION:
                     if Press(CheckIf(screen,option)):
@@ -1307,13 +1306,13 @@ def Factory():
                         if op == 'halfBone':
                             AddImportantInfo("购买了尸油.")
                         return IdentifyState()
-                    
+
                 if pos_b:=CheckIf(screen,'blessing'):
                     if pos:=CheckIf(screen, 'combatClose'): # 如果因为某些原因点到了切换哈肯祝福, 进入了二次确认界面
                         Press(pos) # 我们把二次确认的界面关了, 无事发生
                     else:
                         Press(pos_b)
-                
+
                 if (CheckIf(screen,'multipeopledead')):
                     runtimeContext._SUICIDE = True # 准备尝试自杀
                     logger.info("死了好几个, 惨哦")
@@ -1469,7 +1468,7 @@ def Factory():
                         Press([850,1100])
                         Sleep(3)
                         return
-                    
+
                     logger.info(f"使用技能{targetSpell}, 施法序列特征: {k}:{spellsequence[k]}")
                     if len(spellsequence[k])!=1:
                         spellsequence[k].pop(0)
@@ -1530,7 +1529,7 @@ def Factory():
                 DeviceShell(f"input swipe {swipeDir[0]} {swipeDir[1]} {swipeDir[2]} {swipeDir[3]}")
                 Sleep(2)
                 scn = ScreenShot()
-            
+
             targetPos = None
             if target == 'position':
                 logger.info(f"当前目标: 地点{roi}")
@@ -1595,7 +1594,7 @@ def Factory():
         except KeyError as e:
             logger.info(f"错误: {e}") # 一般来说这里只会返回"地图不可用"
             return None, targetInfoList
-    
+
         if not CheckIf(map,'mapFlag'):
                 return None,targetInfoList # 发生了错误, 应该是进战斗了
 
@@ -1656,7 +1655,7 @@ def Factory():
 
         if runtimeContext._TIME_CHEST==0:
             runtimeContext._TIME_CHEST = time.time()
-        
+
         if setting._QUICKDISARMCHEST:
             if Press(CheckIf(ScreenShot(),'chestFlag')):
                 Sleep(1)
@@ -1703,7 +1702,7 @@ def Factory():
                             Press(disarm)
                             if time.time()-t<0.3:
                                 Sleep(0.3-(time.time()-t))
-                                
+
                         break
                 if not haveBeenTried:
                     haveBeenTried = True
@@ -1716,7 +1715,7 @@ def Factory():
                     ['dungFlag','combatActive','chestFlag','RiseAgain'], # 如果这个fallback重启了, 战斗箱子会直接消失, 固有箱子会是chestFlag
                     [disarm,disarm,disarm,disarm,disarm,disarm,disarm,disarm],
                     1)
-            
+
             if CheckIf(scn,'RiseAgain'):
                 RiseAgainReset(reason = 'chest')
                 return None
@@ -1724,7 +1723,7 @@ def Factory():
                 return DungeonState.Dungeon
             if StateCombatCheck(scn):
                 return DungeonState.Combat
-            
+
             TryPressRetry(scn)
     def StateDungeon(targetInfoList : list[TargetInfo]):
         gameFrozen_none = []
@@ -1734,7 +1733,7 @@ def Factory():
         waitTimer = time.time()
         needRecoverBecauseCombat = False
         needRecoverBecauseChest = False
-        
+
         nonlocal runtimeContext
         runtimeContext._SHOULDAPPLYSPELLSEQUENCE = True
         while 1:
@@ -1885,7 +1884,7 @@ def Factory():
                         dungState = DungeonState.Map
                 case DungeonState.Map:
                     ########### 重置施法序列 - 默认值(第一次)和重启后应当直接应用序列
-                    if runtimeContext._SHOULDAPPLYSPELLSEQUENCE: 
+                    if runtimeContext._SHOULDAPPLYSPELLSEQUENCE:
                         runtimeContext._SHOULDAPPLYSPELLSEQUENCE = False
                         if targetInfoList[0].activeSpellSequenceOverride:
                             logger.info("因为初始化, 复制了施法序列.")
@@ -1895,7 +1894,7 @@ def Factory():
                     def startAuto():
                         for tar in ["chest_auto","mark_auto"]:
                             if targetInfoList[0] and (targetInfoList[0].target == tar):
-                                
+
                                 lastscreen = ScreenShot()
                                 if not Press(CheckIf(lastscreen,tar,[[710,250,180,180]])):
                                     Press(CheckIf(lastscreen,"mapflag"))
@@ -1904,7 +1903,7 @@ def Factory():
                                     lastscreen = ScreenShot()
                                     if not Press(CheckIf(lastscreen,tar,[[710,250,180,180]])):
                                         return None # 如果我们两次检测失败, 认为发生了异常
-                                
+
                                 if tar == "chest_auto":
                                     lastscreen = ScreenShot()
                                     if CheckIf(lastscreen,"NoChestCanBeFound") or CheckIf(lastscreen,"theRouteToTheDestinationCannotBeFound"):
@@ -1920,7 +1919,7 @@ def Factory():
                                 Sleep(1)
                                 Press(CheckIf(lastscreen,'resume')) # 立刻按一次resume 以兼容暴风雪场景.
                                 return StateMoving_CheckFrozen()
-                            
+
                         return DungeonState.Dungeon
 
                     dungState = startAuto()
@@ -1933,7 +1932,7 @@ def Factory():
                     Press([777,150])
 
                     dungState, newTargetInfoList = StateSearch(waitTimer,targetInfoList)
-                    
+
                     if newTargetInfoList == targetInfoList:
                         gameFrozen_map +=1
                         logger.info(f"地图卡死检测:{gameFrozen_map}")
@@ -2384,7 +2383,7 @@ def Factory():
                         lambda: TeleportFromCityToWorldLocation('City_RoyalCityLuknalia','input swipe 450 150 500 150'),
                         lambda: FindCoordsOrElseExecuteFallbackAndWait('guild',['City_RoyalCityLuknalia',[1,1]],1),
                         )
-               
+
                     RestartableSequenceExecution(
                         lambda: logger.info('第四步: 领取任务'),
                         lambda: StateAcceptRequest('LBC/Request',[266,257]),
@@ -2513,14 +2512,14 @@ def Factory():
                         lambda: TeleportFromCityToWorldLocation('City_RoyalCityLuknalia','input swipe 450 150 500 150'),
                         lambda: FindCoordsOrElseExecuteFallbackAndWait('guild',['City_RoyalCityLuknalia',[1,1]],1),
                         )
-                    
+
                     RestartableSequenceExecution(
                         lambda: logger.info('第四步: 领取任务'),
                         lambda: FindCoordsOrElseExecuteFallbackAndWait(['COS/Okay','guildRequest'],['guild',[1,1]],1),
                         lambda: FindCoordsOrElseExecuteFallbackAndWait('Inn',['COS/Okay','return',[1,1]],1),
                         lambda: StateInn(),
                         )
-                    
+
                     RestartableSequenceExecution(
                         lambda: logger.info('第五步: 进入洞窟'),
                         lambda: Press(FindCoordsOrElseExecuteFallbackAndWait('COS/COS',['EdgeOfTown',[1,1]],1)),
@@ -2547,7 +2546,7 @@ def Factory():
                         lambda: StateDungeon(cosb2f)
                         )
 
-                    quest._SPECIALFORCESTOPINGSYMBOL = ['COS/requestwasfor'] 
+                    quest._SPECIALFORCESTOPINGSYMBOL = ['COS/requestwasfor']
                     cosb3f = [TargetInfo('stair_3',"左上",[720,822]),
                               TargetInfo('position',"左下",[239,600]),
                               TargetInfo('position',"左下",[185,1185]),
@@ -2559,7 +2558,7 @@ def Factory():
                         )
 
                     quest._SPECIALFORCESTOPINGSYMBOL = None
-                    quest._SPECIALDIALOGOPTION = ['COS/requestwasfor'] 
+                    quest._SPECIALDIALOGOPTION = ['COS/requestwasfor']
                     cosback2f = [
                                  TargetInfo('stair_2',"左下",[827,547]),
                                  TargetInfo('position',"右上",[340+54,448]),
@@ -2575,7 +2574,7 @@ def Factory():
                         )
                     Press(FindCoordsOrElseExecuteFallbackAndWait("guild",['return',[1,1]],1)) # 回城
                     FindCoordsOrElseExecuteFallbackAndWait("Inn",['return',[1,1]],1)
-                    
+
                 pass
             case 'gaintKiller':
                 while 1:
@@ -2594,7 +2593,7 @@ def Factory():
                     RestartableSequenceExecution(
                         lambda: StateEoT()
                         )
-                    
+
                     # RestartableSequenceExecution(
                     #     lambda: StateDungeon([TargetInfo('position','左上',[560,928])]),
                     #     lambda: FindCoordsOrElseExecuteFallbackAndWait('dungFlag','return',1)
@@ -2613,7 +2612,7 @@ def Factory():
                     #     lambda: FindCoordsOrElseExecuteFallbackAndWait('Inn',['returntotown','returnText','leaveDung','dialogueChoices/blessing',[1,1]],2)
                     # )
                     #     continue
-                    
+
                     # logger.info("发现了巨人.")
                     logger.info("跳过了巨人检测环节. 现在默认总是击杀灯怪.")
                     RestartableSequenceExecution(
@@ -2636,7 +2635,7 @@ def Factory():
                     runtimeContext._COUNTERDUNG += 1
 
                     if not setting._ACTIVE_BEAUTIFUL_ORE:
-                        if not setting._ACTIVE_TRIUMPH:                            
+                        if not setting._ACTIVE_TRIUMPH:
                             logger.info("第一步: 时空跳跃...")
                             RestartableSequenceExecution(
                                 lambda: CursedWheelTimeLeap()
@@ -2646,7 +2645,7 @@ def Factory():
                             RestartableSequenceExecution(
                                 lambda: FindCoordsOrElseExecuteFallbackAndWait('Inn',['returntotown','returnText','leaveDung','dialogueChoices/blessing',[1,1]],2)
                                 )
-                                
+
                             logger.info("第三步: 前往王城...")
                             RestartableSequenceExecution(
                                 lambda:TeleportFromCityToWorldLocation('City_RoyalCityLuknalia','input swipe 450 150 500 150'),
@@ -2657,7 +2656,7 @@ def Factory():
                                 lambda: CursedWheelTimeLeap(chapter='cursedwheel_impregnableFortress', target="Triumph")
                             )
                             Sleep(10)
-                                
+
                             logger.info("第三步: 前往王城...")
                             RestartableSequenceExecution(
                                 lambda:TeleportFromCityToWorldLocation('City_RoyalCityLuknalia','input swipe 450 150 500 150'),
@@ -2687,7 +2686,7 @@ def Factory():
                         lambda:StateDungeon([TargetInfo('position','左下',[505,760]),
                                              TargetInfo('position','左上',[506,821])]),
                         )
-                    
+
                     logger.info("第六步: 提交悬赏")
                     RestartableSequenceExecution(
                         lambda:FindCoordsOrElseExecuteFallbackAndWait("guild",['return',[1,1]],1),
@@ -2698,13 +2697,13 @@ def Factory():
                     RestartableSequenceExecution(
                         lambda:FindCoordsOrElseExecuteFallbackAndWait('EdgeOfTown',['return',[1,1]],1)
                         )
-                    
+
                     logger.info("第七步: 休息")
                     if ((runtimeContext._COUNTERDUNG-1) % (setting._RESTINTERVEL+1) == 0):
                         RestartableSequenceExecution(
                             lambda:StateInn()
                             )
-                        
+
                     costtime = time.time()-starttime
                     total_time = total_time + costtime
                     logger.info(f"第{runtimeContext._COUNTERDUNG}次\"悬赏:蝎女\"完成. \n该次花费时间{costtime:.2f}s.\n总计用时{total_time:.2f}s.\n平均用时{total_time/runtimeContext._COUNTERDUNG:.2f}",
@@ -2726,7 +2725,7 @@ def Factory():
 
                     pos = CheckIf(ScreenShot(),'Steel')
                     Press([pos[0]+306,pos[1]+258])
-                    
+
                     quest._SPECIALDIALOGOPTION = ['ready','noneed', 'quit']
                     RestartableSequenceExecution(
                         lambda:StateDungeon([TargetInfo('position','左上',[131,769]),
@@ -2735,7 +2734,7 @@ def Factory():
                                     TargetInfo('position','左下',[719,1080]),
                                     ])
                                   )
-                    
+
                     if ((runtimeContext._COUNTERDUNG-1) % (setting._RESTINTERVEL+1) == 0):
                         RestartableSequenceExecution(
                             lambda:StateInn()
@@ -2782,11 +2781,11 @@ def Factory():
                     RestartableSequenceExecution(
                         lambda:FindCoordsOrElseExecuteFallbackAndWait('dungFlag',['EdgeOfTown','beginningAbyss','B4FLabyrinth','GotoDung',[1,1]],1)
                         )
-                    RestartableSequenceExecution( 
+                    RestartableSequenceExecution(
                         lambda:StateDungeon([TargetInfo('position','左下',[452,1026]),
                                              TargetInfo('harken','左上',None)]),
                         )
-                    
+
                     logger.info("第六步: 提交悬赏")
                     RestartableSequenceExecution(
                         lambda:FindCoordsOrElseExecuteFallbackAndWait("guild",['return',[1,1]],1),
@@ -2797,13 +2796,13 @@ def Factory():
                     RestartableSequenceExecution(
                         lambda:FindCoordsOrElseExecuteFallbackAndWait('EdgeOfTown',['return',[1,1]],1)
                         )
-                    
+
                     logger.info("第七步: 休息")
                     if ((runtimeContext._COUNTERDUNG-1) % (setting._RESTINTERVEL+1) == 0):
                         RestartableSequenceExecution(
                             lambda:StateInn()
                             )
-                        
+
                     costtime = time.time()-starttime
                     total_time = total_time + costtime
                     logger.info(f"第{runtimeContext._COUNTERDUNG}次\"悬赏:吉尔\"完成. \n该次花费时间{costtime:.2f}s.\n总计用时{total_time:.2f}s.\n平均用时{total_time/runtimeContext._COUNTERDUNG:.2f}",
@@ -2824,7 +2823,7 @@ def Factory():
         setting = set
 
         Sleep(1) # 没有等utils初始化完成
-        
+
         ResetDevice()
 
         quest = LoadQuest()


### PR DESCRIPTION
1. 那个`script.py`中拆分了`CONFIG_VAR_LIST`到`config_vars.py`，不然会有全局引用冲突
2. 新增了`quest_manager.py`，内含单例类`QuestManager`，负责读取所有任务数据，除了会读取原有的内置数据外，还会额外读取工作目录下quest子目录（如不存在会自动创建）下的所有.json加入到任务中，方便扩展和分享。重复的`quest_code`或`quest_name`，会被舍弃，并在GUI初始化完后打印错误日志到消息窗口中
3. 新增了`config_manager.py`，内含单例类`ConfigManager`，实现的功能为：原工作目录下的`config.json`只提供少量共用配置（包括模拟器配置、善恶度记录），其他配置（关卡、休息配置、战斗配置等）读取另外一个配置文件。第二个配置文件为工作目录下config子目录（如不存在会自动创建，对于老用户会将原有根目录config复制一份作为初始配置，新用户会读取默认值生成一份初始配置）下的所有.json文件，每个json文件对应一个配置，可以通过GUI进行切换，方便切换不同的配置刷不同的本

进行了简单的测试，感觉上大概也许可能没问题