### PR TITLE
开箱失败导致长时间卡死的bug

### DIFF
--- a/resources/quest/quest.json
+++ b/resources/quest/quest.json
@@ -274,10 +274,10 @@
     },
     "fordraig-B3F":{
         "_TYPE":"dungeon",
-        "questName":"[宝箱]鸟洞fordraig 3F",
+        "questName":"[宝箱]弗德莱戈的迷宫三层fordraigB3F",
         "_TARGETINFOLIST":[
             ["chest_auto"],
-            ["harken"]
+            ["harken",[[100,1200,700,100],[700,800,100,800],[400,100,400,1200],[100,800,700,800],[400,1200,400,100]]]
         ],
         "_preEOTcheck":"fordraig/B3F",
         "_EOT":[

--- a/src/script.py
+++ b/src/script.py
@@ -1955,6 +1955,15 @@ def Factory():
             if CheckIf(scn,"RiseAgain"):
                 RiseAgainReset(reason = "chest")
                 return None
+            
+            # 此处易出bug：在开箱失败的情况下，会播放人物掉血的动画，此时小地图会短暂显示出来
+            # 若顶部的while loop恰好在此时截图，会判断画面中有"dungFlag"，然而实际上还在开箱结算界面
+            # 进而导致此处返回DungeonState.Dungeon，然后StateDungeon进入case DungeonState.Dungeon尝试resume但是没有resume按钮
+            # 然后导致转DungeonState.Map尝试打开地图，StateSearch(.)找不到地图会转到dungState = None
+            # 此时StateDungeon(.)开始重新IdentifyState()，但是宝箱结算界面不能被识别
+            # 于是IdentifyState()一直要重新识别到开始尝试点击[1,1]才能把结算对话过掉
+            # 解决方法很简单：重新截图，在图像识别的时候保持截图是最新的
+            scn = ScreenShot()
             if CheckIf(scn,"dungFlag"):
                 return DungeonState.Dungeon
             if CheckIf(scn, "ambush"):

--- a/src/script.py
+++ b/src/script.py
@@ -1956,13 +1956,7 @@ def Factory():
                 RiseAgainReset(reason = "chest")
                 return None
             
-            # 此处易出bug：在开箱失败的情况下，会播放人物掉血的动画，此时小地图会短暂显示出来
-            # 若顶部的while loop恰好在此时截图，会判断画面中有"dungFlag"，然而实际上还在开箱结算界面
-            # 进而导致此处返回DungeonState.Dungeon，然后StateDungeon进入case DungeonState.Dungeon尝试resume但是没有resume按钮
-            # 然后导致转DungeonState.Map尝试打开地图，StateSearch(.)找不到地图会转到dungState = None
-            # 此时StateDungeon(.)开始重新IdentifyState()，但是宝箱结算界面不能被识别
-            # 于是IdentifyState()一直要重新识别到开始尝试点击[1,1]才能把结算对话过掉
-            # 解决方法很简单：重新截图，在图像识别的时候保持截图是最新的
+            # 在图像识别的时候保持截图是最新的
             scn = ScreenShot()
             if CheckIf(scn,"dungFlag"):
                 return DungeonState.Dungeon


### PR DESCRIPTION
我发现脚本经常卡在开完箱子后的结算画面里（对话显示你获得了什么东西的画面），直到重新尝试识别地下城状态5次以后才能过掉结算画面。经调查只有开箱失败的时候会发生，已修复并通过测试。详细原因请看注释。