### PR TITLE
新增 GPG 模拟器与多设备管理支持

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 # 临时文件
 __pycache__/
 src/__pycache__/
+.pycache
 
 # 本地测试文件
 log.txt

--- a/src/device.py
+++ b/src/device.py
@@ -1,0 +1,745 @@
+from pathlib import Path, PureWindowsPath
+import os
+import re
+import subprocess
+import time
+
+from ppadb.client import Client as AdbClient
+
+from utils import logger
+
+
+PACKAGE_NAME = "jp.co.drecom.wizardry.daphne"
+
+
+def device_path(value):
+    text = str(value or "")
+    if os.name == "nt":
+        return Path(text)
+    if "\\" in text or (len(text) >= 2 and text[1] == ":"):
+        return PureWindowsPath(text)
+    return Path(text)
+
+
+def path_exists(path):
+    return hasattr(path, "exists") and path.exists()
+
+
+class Device:
+    device_type = "physical"
+    display_name = _("实体设备")
+    can_restart_emulator = False
+    visible_config_fields = ["adb_path", "adb_address"]
+    address_label = _("ADB连接地址:")
+    visible_path_rows = ["adb"]
+    default_adb_address = ""
+    default_adb_paths = []
+    setup_display_after_connect = False
+    display_size = "900x1600"
+    display_density = "240"
+    restore_display_on_stop = False
+    close_game_on_stop = False
+
+    def __init__(self, setting, runtime_context):
+        self.setting = setting
+        self.runtime_context = runtime_context
+
+    @property
+    def serial(self):
+        return self.setting.ADB_ADRESS
+
+    @property
+    def adb_path(self):
+        adb_path = getattr(self.setting, "ADB_PATH", None)
+        if adb_path:
+            return device_path(adb_path)
+        default_path = self.first_existing_default_adb_path()
+        if default_path:
+            return default_path
+        return Path("adb")
+
+    @classmethod
+    def iter_default_adb_paths(cls):
+        for path in cls.default_adb_paths:
+            yield path
+        if os.name == "nt":
+            yield str(Path.home() / "Documents" / "platform-tools" / "adb.exe")
+
+    @classmethod
+    def first_existing_default_adb_path(cls):
+        for adb_path in cls.iter_default_adb_paths():
+            path = device_path(adb_path)
+            if path_exists(path):
+                return path
+        return None
+
+    def _run_adb(self, *args, timeout=10):
+        cmd = [str(self.adb_path), *[str(arg) for arg in args]]
+        logger.debug(_("执行adb命令: {a}").format(a=" ".join(cmd)))
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            encoding="utf-8",
+            errors="ignore",
+        )
+        logger.debug(_("adb命令返回:{a}").format(a=result.stdout))
+        if result.stderr:
+            logger.debug(_("adb命令错误:{a}").format(a=result.stderr))
+        if result.returncode != 0:
+            logger.error(_("adb命令执行失败(exit={a}): {b}").format(a=result.returncode, b=result.stderr or result.stdout))
+        return result
+
+    def _adb_command_failed(self, result):
+        return getattr(result, "returncode", 0) != 0
+
+    def _adb_device_state(self, devices_output):
+        for line in str(devices_output or "").splitlines():
+            parts = line.strip().split()
+            if len(parts) >= 2 and parts[0] == str(self.serial):
+                return parts[1]
+        return None
+
+    def validate_adb_path(self):
+        if str(self.adb_path) == "adb":
+            return True
+        if not path_exists(self.adb_path):
+            logger.error(_("adb程序不存在: {a}").format(a=self.adb_path))
+            return False
+        return True
+
+    def kill_adb(self):
+        self._kill_processes([self.adb_path.name])
+
+    def recover_adb(self):
+        logger.info(_("正在检查并关闭adb..."))
+        self.kill_adb()
+        logger.info(_("已尝试终止adb"))
+
+    def setup_display(self):
+        logger.info(_("设置设备分辨率为{a}, DPI为{b}.").format(a=self.display_size, b=self.display_density))
+        size_result = self._run_adb("-s", self.serial, "shell", "wm", "size", self.display_size)
+        density_result = self._run_adb("-s", self.serial, "shell", "wm", "density", self.display_density)
+        if size_result.returncode != 0 or density_result.returncode != 0:
+            logger.error(
+                _("设置设备分辨率或DPI失败: size={a}, density={b}").format(
+                    a=size_result.stderr or size_result.stdout,
+                    b=density_result.stderr or density_result.stdout,
+                )
+            )
+
+    def restore_display(self):
+        if not self.restore_display_on_stop:
+            return True
+        logger.info(_("恢复设备分辨率与DPI设置."))
+        size_result = self._run_adb("-s", self.serial, "shell", "wm", "size", "reset")
+        density_result = self._run_adb("-s", self.serial, "shell", "wm", "density", "reset")
+        if size_result.returncode != 0 or density_result.returncode != 0:
+            logger.error(
+                _("恢复设备分辨率或DPI失败: size={a}, density={b}").format(
+                    a=size_result.stderr or size_result.stdout,
+                    b=density_result.stderr or density_result.stdout,
+                )
+            )
+            return False
+        return True
+
+    def close_game(self, package_name=PACKAGE_NAME):
+        if not getattr(self.setting, "_ADBDEVICE", None):
+            logger.warning(_("ADB设备尚未连接，跳过关闭游戏."))
+            return False
+        logger.info(_("关闭游戏: {a}").format(a=package_name))
+        self.shell(f"am force-stop {package_name}")
+        return True
+
+    def cleanup_after_stop(self):
+        close_ok = True
+        if self.close_game_on_stop:
+            try:
+                close_ok = self.close_game()
+            except Exception as e:
+                close_ok = False
+                logger.error(_("关闭游戏时出错: {a}").format(a=e))
+        display_ok = self.restore_display()
+        return close_ok and display_ok
+
+    def after_connect(self):
+        if self.setup_display_after_connect:
+            self.setup_display()
+
+    def connect(self, force_restart_emu=False, force_restart_adb=False):
+        if force_restart_emu:
+            self.restart_target()
+            time.sleep(1)
+        if force_restart_adb:
+            self.recover_adb()
+            time.sleep(1)
+        return self._connect_adb()
+
+    def _connect_adb(self):
+        if not self.validate_adb_path():
+            return None
+
+        max_retries = 20
+        for attempt in range(max_retries):
+            logger.info(_("-----------------------\n开始尝试连接adb. 次数:{a}/{b}...").format(a=attempt + 1, b=max_retries))
+            if attempt == 3:
+                logger.info(_("失败次数过多, 尝试关闭adb."))
+                self.recover_adb()
+
+            try:
+                result = self._run_adb("devices")
+                if self._adb_command_failed(result):
+                    time.sleep(2)
+                    continue
+                state = self._adb_device_state(result.stdout)
+                if ("daemon not running" in result.stderr) or state == "offline":
+                    time.sleep(2)
+                    result = self._run_adb("devices")
+                    if self._adb_command_failed(result):
+                        time.sleep(2)
+                        continue
+                    state = self._adb_device_state(result.stdout)
+                    if ("daemon not running" in result.stderr) or state == "offline":
+                        logger.info(_("adb服务未启动!\n启动adb服务..."))
+                        self._run_adb("kill-server")
+                        self._run_adb("start-server")
+                        time.sleep(2)
+
+                state = self._adb_device_state(result.stdout)
+                if self._should_adb_connect() and state != "device":
+                    logger.debug(_("尝试连接到adb..."))
+                    connect_result = self._run_adb("connect", self.serial)
+                    if self._adb_command_failed(connect_result):
+                        time.sleep(2)
+                        continue
+
+                result = self._run_adb("devices")
+                if self._adb_command_failed(result):
+                    time.sleep(2)
+                    continue
+                state = self._adb_device_state(result.stdout)
+                if state == "device":
+                    logger.info(_("成功连接到设备: {a}").format(a=self.serial))
+                    self.capture_running_pid()
+                    device = self._create_ppadb_device()
+                    if device:
+                        self.after_connect()
+                        return device
+                if state == "offline":
+                    logger.info(_("设备处于offline状态，尝试重启ADB服务: {a}").format(a=self.serial))
+                    self.recover_adb()
+                    time.sleep(2)
+                    continue
+
+                if isinstance(self, EmulatorDevice) and not self.is_running():
+                    logger.info(_("模拟器未运行，尝试启动..."))
+                    if self.start_emulator():
+                        logger.info(_("模拟器(应该)启动完毕.\n 尝试连接到模拟器..."))
+                        if self._should_adb_connect():
+                            self._run_adb("connect", self.serial)
+                        continue
+
+                logger.info(_("连接失败: {a}").format(a=result.stderr.strip()))
+                time.sleep(2)
+                if isinstance(self, EmulatorDevice) and self.restart_on_connect_failure:
+                    self.kill_emulator()
+                    self.recover_adb()
+                time.sleep(2)
+            except Exception as e:
+                logger.error(_("重启ADB服务时出错: {a}").format(a=e))
+                time.sleep(2)
+                if isinstance(self, EmulatorDevice) and self.restart_on_connect_failure:
+                    self.kill_emulator()
+                    self.recover_adb()
+                time.sleep(2)
+                return None
+
+        logger.info(_("达到最大重试次数，连接失败"))
+        return None
+
+    def _should_adb_connect(self):
+        return ":" in str(self.serial)
+
+    def _create_ppadb_device(self):
+        try:
+            client = AdbClient(host="127.0.0.1", port=5037)
+            for device in client.devices():
+                if device.serial == str(self.serial):
+                    logger.info(_("成功创建设备对象: {a}").format(a=device.serial))
+                    self.setting._ADBDEVICE = device
+                    return device
+        except Exception as e:
+            logger.error(_("创建ADB设备时出错: {a}").format(a=e))
+        return None
+
+    def capture_running_pid(self):
+        pass
+
+    def shell(self, cmd, timeout=5):
+        if not getattr(self.setting, "_ADBDEVICE", None):
+            raise RuntimeError(_("ADB设备尚未连接."))
+        return self.setting._ADBDEVICE.shell(cmd, timeout=timeout)
+
+    def screencap(self):
+        serial = self.setting._ADBDEVICE.serial
+        return subprocess.run(
+            [str(self.adb_path), "-s", serial, "exec-out", "screencap"],
+            capture_output=True,
+            timeout=5,
+        )
+
+    def clear_logcat(self):
+        result = self._run_adb("-s", self.serial, "shell", "logcat", "-b", "all", "-c")
+        if self._adb_command_failed(result):
+            logger.warning(_("清除全部logcat缓冲区失败，尝试清除默认缓冲区."))
+            self._run_adb("-s", self.serial, "shell", "logcat", "-c")
+
+    def find_graphics_api_crash_log(self):
+        result = self._run_adb("-s", self.serial, "shell", "logcat", "-b", "all", "-d", timeout=10)
+        if self._adb_command_failed(result):
+            logger.warning(_("读取logcat失败，跳过图形API崩溃检测."))
+            return ""
+        matched_lines = [
+            line
+            for line in str(result.stdout or "").splitlines()
+            if re.search(r"unable to initialize.*graphics api", line, re.IGNORECASE)
+        ]
+        return "\n".join(matched_lines[-20:])
+
+    def restart_target(self):
+        logger.info(_("当前设备类型不支持重启模拟器/设备, 将仅重启游戏."))
+        return False
+
+    def restart_game(self, package_name=PACKAGE_NAME):
+        if not getattr(self.setting, "_ADBDEVICE", None):
+            raise RuntimeError(_("ADB设备尚未连接."))
+        self.clear_logcat()
+        main_act = self.shell(f"cmd package resolve-activity --brief {package_name}").strip().split("\n")[-1]
+        if not main_act or "/" not in main_act:
+            logger.error(_("无法解析游戏启动Activity: {a}").format(a=main_act))
+            return False
+        self.shell(f"am force-stop {package_name}")
+        logger.info(_("巫术, 启动!"))
+        logger.debug(self.shell(f"am start -n {main_act}"))
+        return True
+
+    def _kill_processes(self, process_names):
+        for name in process_names:
+            if not name:
+                continue
+            try:
+                if os.name == "nt":
+                    subprocess.run(
+                        ["taskkill", "/f", "/im", name],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                        check=False,
+                    )
+                else:
+                    subprocess.run(
+                        ["pkill", "-f", name],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                        check=False,
+                    )
+            except Exception as e:
+                logger.error(_("终止进程{a}时出错: {b}").format(a=name, b=e))
+
+
+class EmulatorDevice(Device):
+    can_restart_emulator = True
+    visible_config_fields = ["emu_path", "adb_address"]
+    address_label = _("ADB连接地址:")
+    visible_path_rows = ["install", "emulator", "adb", "cleanup_processes"]
+    process_names = []
+    adb_process_names = []
+    cleanup_process_names = []
+    default_install_roots = []
+    tracks_single_emulator_process = True
+    restart_on_connect_failure = True
+
+    @property
+    def install_root(self):
+        configured = getattr(self.setting, "EMU_PATH", None)
+        if configured:
+            return self.normalize_install_root(device_path(configured))
+        default_root = self.first_existing_default_root()
+        if default_root:
+            return default_root
+        if self.default_install_roots:
+            return device_path(self.default_install_roots[0])
+        return device_path("")
+
+    def normalize_install_root(self, path):
+        return path
+
+    def first_existing_default_root(self):
+        for root in self.default_install_roots:
+            path = device_path(root)
+            if path_exists(path):
+                return path
+        return None
+
+    @property
+    def emu_path(self):
+        return self.install_root
+
+    def validate_adb_path(self):
+        if not str(self.install_root):
+            logger.error(_("未设置模拟器路径."))
+            return False
+        return super().validate_adb_path()
+
+    def start_emulator(self):
+        raise NotImplementedError
+
+    def detect_running_pids(self):
+        if os.name != "nt":
+            return []
+        names = " ".join(self.process_names)
+        if not names:
+            return []
+        result = subprocess.run(
+            f'tasklist /FO CSV /NH | findstr "{names}"',
+            shell=True,
+            capture_output=True,
+            text=True,
+        )
+        check_results = []
+        for task in result.stdout.strip().split("\n"):
+            if not task:
+                continue
+            parts = task.split("\",\"")
+            if len(parts) >= 2:
+                try:
+                    check_results.append(int(parts[1]))
+                except ValueError:
+                    pass
+        return check_results
+
+    def is_running(self):
+        pid = getattr(self.runtime_context, "_RUNNING_EMU_PID", None)
+        pids = self.detect_running_pids()
+        return bool(pid and pid in pids) or bool(pids)
+
+    def capture_running_pid(self):
+        if not self.tracks_single_emulator_process:
+            logger.debug(_("当前设备类型不追踪单一模拟器进程: {a}").format(a=self.device_type))
+            self.runtime_context._RUNNING_EMU_PID = None
+            return
+
+        pids = self.detect_running_pids()
+        logger.debug("{a}".format(a=pids))
+        if len(pids) == 1:
+            self.runtime_context._RUNNING_EMU_PID = int(pids[0])
+            logger.info(_("模拟器进程号为{a}.").format(a=self.runtime_context._RUNNING_EMU_PID))
+        elif len(pids) > 1:
+            logger.info(_("\n\n***********\n有多个模拟器已经启动, 无法识别进程号. 当需要重启模拟器的时候, 会重启所有模拟器.\n为了避免此问题, 请关闭目标模拟器, 并使用本脚本自动启动模拟器.\n\n"))
+
+    def kill_adb(self):
+        self._kill_processes(self.adb_process_names or [self.adb_path.name])
+
+    def kill_emulator(self):
+        emulator_name = self.emu_path.name if self.emu_path.name else None
+        try:
+            logger.info(_("正在检查并关闭已运行的模拟器实例{a}...").format(a=emulator_name or self.display_name))
+            pid = getattr(self.runtime_context, "_RUNNING_EMU_PID", None)
+            if os.name == "nt" and pid:
+                logger.info(_("使用已知进程号{a}关闭模拟器...").format(a=pid))
+                subprocess.run(
+                    ["taskkill", "/F", "/PID", str(pid)],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    check=False,
+                )
+                time.sleep(1)
+            else:
+                names = list(self.process_names)
+                if emulator_name and emulator_name not in names:
+                    names.append(emulator_name)
+                self._kill_processes(names)
+                time.sleep(1)
+            self._kill_processes(self.cleanup_process_names)
+            logger.info(_("已尝试终止模拟器进程: {a}").format(a=emulator_name or self.display_name))
+        except Exception as e:
+            logger.error(_("终止模拟器进程时出错: {a}").format(a=str(e)))
+        finally:
+            self.runtime_context._RUNNING_EMU_PID = None
+
+    def restart_target(self):
+        self.kill_emulator()
+        time.sleep(1)
+        self.start_emulator()
+        return True
+
+
+class MuMuEmulatorDevice(EmulatorDevice):
+    device_type = "mumu"
+    display_name = "MuMu"
+    visible_config_fields = ["emu_path", "adb_address", "emu_index"]
+    process_names = ["MuMuNxDevice.exe", "MuMuPlayer.exe"]
+    adb_process_names = ["adb.exe"]
+    cleanup_process_names = ["MuMuVMMSVC.exe", "MuMuVMMHeadless.exe"]
+    default_install_roots = [
+        r"C:\Program Files\Netease\MuMuPlayer",
+        r"C:\Program Files (x86)\MuMuPlayer",
+    ]
+
+    @property
+    def shell_dir(self):
+        root = self.install_root
+        if root.name.lower() == "shell":
+            return root
+        return root / "nx_device" / "12.0" / "shell"
+
+    def normalize_install_root(self, path):
+        if path.name.lower() in ["mumunxdevice.exe", "mumuplayer.exe", "adb.exe"]:
+            path = path.parent
+        if path.name.lower() == "shell":
+            return path.parent.parent.parent
+        return path
+
+    @property
+    def emu_path(self):
+        shell_dir = self.shell_dir
+        nx_device = shell_dir / "MuMuNxDevice.exe"
+        if path_exists(nx_device):
+            return nx_device
+        return shell_dir / "MuMuPlayer.exe"
+
+    @property
+    def adb_path(self):
+        return self.shell_dir / "adb.exe"
+
+    def start_emulator(self):
+        if not path_exists(self.emu_path):
+            logger.error(_("模拟器启动程序不存在: {a}").format(a=self.emu_path))
+            return False
+        cmd = [str(self.emu_path), "control", "-v", str(self.setting.EMU_INDEX)]
+        try:
+            logger.info(_("启动模拟器: {a}").format(a=" ".join(cmd)))
+            pre_pids = self.detect_running_pids()
+            subprocess.Popen(
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                cwd=str(self.shell_dir),
+            )
+            time.sleep(5)
+            aft_pids = self.detect_running_pids()
+            new_tasks = [pid for pid in aft_pids if pid not in pre_pids]
+            if new_tasks:
+                self.runtime_context._RUNNING_EMU_PID = int(new_tasks[0])
+                logger.info(_("模拟器启动开始，进程号为{a}").format(a=self.runtime_context._RUNNING_EMU_PID))
+        except Exception as e:
+            logger.error(_("启动模拟器失败: {a}").format(a=str(e)))
+            return False
+        logger.info(_("等待模拟器启动..."))
+        time.sleep(15)
+        return True
+
+
+class BlueStacksEmulatorDevice(EmulatorDevice):
+    device_type = "bluestacks"
+    display_name = "BlueStacks Legacy"
+    process_names = ["HD-Player.exe"]
+    adb_process_names = ["HD-Adb.exe"]
+    default_install_roots = [
+        r"C:\Program Files\BlueStacks_nxt",
+        r"C:\Program Files\BlueStacks",
+    ]
+
+    def normalize_install_root(self, path):
+        if path.name.lower() in ["hd-adb.exe", "hd-player.exe"]:
+            return path.parent
+        return path
+
+    @property
+    def emu_path(self):
+        return self.install_root / "HD-Player.exe"
+
+    @property
+    def adb_path(self):
+        return self.install_root / "HD-Adb.exe"
+
+    def start_emulator(self):
+        if not path_exists(self.emu_path):
+            logger.error(_("模拟器启动程序不存在: {a}").format(a=self.emu_path))
+            return False
+        try:
+            logger.info(_("启动模拟器: {a}").format(a=self.emu_path))
+            subprocess.Popen(
+                [str(self.emu_path)],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                cwd=str(self.install_root),
+            )
+            time.sleep(15)
+            return True
+        except Exception as e:
+            logger.error(_("启动模拟器失败: {a}").format(a=str(e)))
+            return False
+
+
+class GooglePlayGamesDevEmulatorDevice(EmulatorDevice):
+    device_type = "gpg_dev"
+    display_name = "Google Play Games Developer Emulator"
+    visible_path_rows = ["install", "emulator", "adb"]
+    process_names = ["Service.exe"]
+    adb_process_names = ["adb.exe"]
+    default_adb_address = "localhost:6520"
+    tracks_single_emulator_process = False
+    restart_on_connect_failure = False
+    setup_display_after_connect = True
+    default_install_roots = [
+        r"C:\Program Files\Google\Play Games Developer Emulator",
+    ]
+
+    @property
+    def base_dir(self):
+        path = self.install_root
+        if path.name.lower() == "emulator":
+            return path
+        return path / "current" / "emulator"
+
+    def normalize_install_root(self, path):
+        if path.name.lower() in ["adb.exe", "crosvm.exe", "service.exe"]:
+            path = path.parent
+        if path.name.lower() == "service":
+            return path.parent.parent
+        if path.name.lower() == "emulator":
+            return path.parent.parent
+        return path
+
+    @property
+    def startup_bin(self):
+        return self.install_root / "Bootstrapper.exe"
+
+    @property
+    def emu_path(self):
+        return self.install_root / "current" / "service" / "Service.exe"
+
+    @property
+    def adb_path(self):
+        return self.base_dir / "adb.exe"
+
+    def detect_running_pids(self):
+        if os.name != "nt":
+            return []
+        root = str(self.install_root).rstrip("\\/").replace("'", "''")
+        root_prefix = f"{root}\\"
+        script = (
+            "Get-CimInstance Win32_Process -Filter \"Name = 'Service.exe'\" | "
+            f"Where-Object {{ $_.ExecutablePath -and $_.ExecutablePath.StartsWith('{root_prefix}', "
+            "[System.StringComparison]::OrdinalIgnoreCase) }} | "
+            "ForEach-Object { $_.ProcessId }"
+        )
+        result = subprocess.run(
+            ["powershell", "-NoProfile", "-Command", script],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.stderr:
+            logger.debug(_("GPG服务进程查询错误:{a}").format(a=result.stderr))
+        pids = []
+        for line in result.stdout.splitlines():
+            line = line.strip()
+            if line.isdigit():
+                pids.append(int(line))
+        logger.info(_("找到GPG模拟器服务进程: {a}").format(a=pids))
+        return pids
+
+    def kill_emulator(self):
+        try:
+            logger.info(_("正在检查并关闭GPG模拟器服务: {a}...").format(a=self.emu_path))
+            pids = self.detect_running_pids()
+            if not pids:
+                logger.info(_("未找到正在运行的GPG模拟器服务."))
+                return
+            for pid in pids:
+                logger.info(_("使用进程号{a}关闭GPG模拟器服务...").format(a=pid))
+                result = subprocess.run(
+                    ["taskkill", "/F", "/PID", str(pid)],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                if result.returncode != 0:
+                    logger.error(
+                        _("关闭GPG模拟器服务失败(pid={a}, exit={b}): {c}").format(
+                            a=pid,
+                            b=result.returncode,
+                            c=result.stderr or result.stdout,
+                        )
+                    )
+            time.sleep(1)
+            logger.info(_("已尝试终止GPG模拟器服务."))
+        except Exception as e:
+            logger.error(_("终止GPG模拟器服务时出错: {a}").format(a=str(e)))
+        finally:
+            self.runtime_context._RUNNING_EMU_PID = None
+
+    def start_emulator(self):
+        if not path_exists(self.startup_bin):
+            logger.error(_("模拟器启动程序不存在: {a}").format(a=self.startup_bin))
+            return False
+        try:
+            logger.info(_("启动模拟器: {a}").format(a=self.startup_bin))
+            subprocess.Popen(
+                [str(self.startup_bin)],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                cwd=str(self.startup_bin.parent),
+            )
+            time.sleep(15)
+            return True
+        except Exception as e:
+            logger.error(_("启动模拟器失败: {a}").format(a=str(e)))
+            return False
+
+
+class PhysicalAndroidDevice(Device):
+    device_type = "physical"
+    display_name = _("实体设备")
+    setup_display_after_connect = True
+    restore_display_on_stop = True
+    close_game_on_stop = True
+    default_adb_paths = [
+        r"C:\Android\platform-tools\adb.exe",
+    ]
+
+    def validate_adb_path(self):
+        if not getattr(self.setting, "ADB_PATH", None) and str(self.adb_path) == "adb":
+            logger.error(_("实体设备需要设置ADB执行文件."))
+            return False
+        return super().validate_adb_path()
+
+
+DEVICE_REGISTRY = {
+    "mumu": MuMuEmulatorDevice,
+    "bluestacks": BlueStacksEmulatorDevice,
+    "gpg_dev": GooglePlayGamesDevEmulatorDevice,
+    "physical": PhysicalAndroidDevice,
+}
+
+
+def infer_device_type(setting):
+    explicit = getattr(setting, "DEVICE_TYPE", None)
+    if explicit:
+        return explicit
+    emu_path = getattr(setting, "EMU_PATH", "") or ""
+    lowered = str(emu_path).lower()
+    if "hd-player.exe" in lowered or "hd-adb.exe" in lowered:
+        return "bluestacks"
+    if "google\\play games developer emulator" in lowered or "crosvm.exe" in lowered or "service.exe" in lowered:
+        return "gpg_dev"
+    return "mumu"
+
+
+def create_device(setting, runtime_context):
+    device_type = infer_device_type(setting)
+    device_cls = DEVICE_REGISTRY.get(device_type, MuMuEmulatorDevice)
+    return device_cls(setting, runtime_context)

--- a/src/gui.py
+++ b/src/gui.py
@@ -2,7 +2,9 @@ import tkinter as tk
 from tkinter import ttk, scrolledtext, filedialog, messagebox,simpledialog
 import os
 import logging
+import subprocess
 from script import *
+from device import DEVICE_REGISTRY, device_path, path_exists
 from auto_updater import *
 from utils import *
 import webbrowser
@@ -443,6 +445,15 @@ def LoadConfig(specific = 'ALL'):
     elif specific == "default":
         result_config = raw_config.get("DEFAULT", {})
 
+    if specific in ("ALL", "general"):
+        device_type = result_config.get("DEVICE_TYPE")
+        emu_path = str(result_config.get("EMU_PATH") or "").lower()
+        if not device_type:
+            if "hd-player.exe" in emu_path or "hd-adb.exe" in emu_path:
+                result_config["DEVICE_TYPE"] = "bluestacks"
+            else:
+                result_config["DEVICE_TYPE"] = "mumu"
+
     return result_config
 ############################################
 class ConfigPanelApp(tk.Toplevel):
@@ -468,10 +479,11 @@ class ConfigPanelApp(tk.Toplevel):
         self.adb_active = False
 
         # 关闭时退出整个程序
-        self.protocol("WM_DELETE_WINDOW", self.controller.destroy)
+        self.protocol("WM_DELETE_WINDOW", lambda: self.controller.force_shutdown(exit_code=0))
 
         # --- 任务状态 ---
         self.quest_active = False
+        self.quest_stopping = False
 
         # --- 任务点 ---
         self.task_point_vars = {}
@@ -510,6 +522,9 @@ class ConfigPanelApp(tk.Toplevel):
             self.save_config()
     
     def save_config(self):
+        if hasattr(self, "device_type_display") and hasattr(self, "DEVICE_TYPE_OPTIONS"):
+            self.DEVICE_TYPE.set(self.DEVICE_TYPE_OPTIONS.get(self.device_type_display.get(), self.DEVICE_TYPE.get()))
+
         # karma
         if self.KARMA_ADJUST.get().isdigit():
             valuestr = self.KARMA_ADJUST.get()
@@ -517,7 +532,24 @@ class ConfigPanelApp(tk.Toplevel):
 
         # emu path
         emu_path = self.EMU_PATH.get()
-        emu_path = emu_path.replace("HD-Adb.exe", "HD-Player.exe")
+        if self.DEVICE_TYPE.get() == "bluestacks":
+            path = device_path(emu_path) if emu_path else None
+            if path and path.name.lower() in ["hd-adb.exe", "hd-player.exe"]:
+                emu_path = str(path.parent)
+        elif self.DEVICE_TYPE.get() == "mumu":
+            path = device_path(emu_path) if emu_path else None
+            if path and path.name.lower() in ["adb.exe", "mumuplayer.exe", "mumunxdevice.exe"]:
+                emu_path = str(path.parent)
+            if path and path.name.lower() == "shell":
+                emu_path = str(path.parent.parent.parent)
+        elif self.DEVICE_TYPE.get() == "gpg_dev":
+            path = device_path(emu_path) if emu_path else None
+            if path and path.name.lower() in ["adb.exe", "crosvm.exe", "service.exe"]:
+                emu_path = str(path.parent)
+            if path and path.name.lower() == "service":
+                emu_path = str(path.parent.parent)
+            if path and path.name.lower() == "emulator":
+                emu_path = str(path.parent.parent)
         self.EMU_PATH.set(emu_path)
 
         # farm target
@@ -594,67 +626,404 @@ class ConfigPanelApp(tk.Toplevel):
         content_root = self.scroll_view.scrollable_frame
 
         # ==========================================
-        # 分组 1: 基础设置 & 模拟器
+        # 分组 1: 基础设置 & 设备
         # ==========================================
-        self.section_emu = CollapsibleSection(content_root, title=_("模拟器"), expanded= False if self.EMU_PATH.get() else True,)
+        self.section_emu = CollapsibleSection(content_root, title=_("设备"), expanded= False if self.EMU_PATH.get() or self.ADB_PATH.get() else True,)
         self.section_emu.pack(fill="x", pady=(0, 5)) # 使用pack垂直堆叠
         
         # 获取折叠板的内容容器
         container = self.section_emu.content_frame 
 
-        row_counter = 0 
+        row_counter = 0
         frame_row = ttk.Frame(container)
         frame_row.grid(row=row_counter, column=0, sticky="ew", pady=2)
-        
+        ttk.Label(frame_row, text=_("类型:")).grid(row=0, column=0, sticky=tk.W, padx=(5, 0), pady=2)
+        self.DEVICE_TYPE_OPTIONS = {
+            _("MuMu 模拟器"): "mumu",
+            _("BlueStacks Legacy"): "bluestacks",
+            _("Google Play 游戏电脑版开发人员模拟器"): "gpg_dev",
+            _("实体设备"): "physical",
+        }
+        self.DEVICE_TYPE_LABELS = {value: key for key, value in self.DEVICE_TYPE_OPTIONS.items()}
+        self.device_type_display = tk.StringVar(value=self.DEVICE_TYPE_LABELS.get(self.DEVICE_TYPE.get(), _("MuMu 模拟器")))
+        self.device_type_combobox = ttk.Combobox(
+            frame_row,
+            textvariable=self.device_type_display,
+            values=list(self.DEVICE_TYPE_OPTIONS.keys()),
+            state="readonly",
+            width=28,
+        )
+        self.device_type_combobox.grid(row=0, column=1, sticky=tk.W, padx=5, pady=2)
         self.adb_status_label = ttk.Label(frame_row)
-        self.adb_status_label.grid(row=0, column=0)
-        
-        adb_entry = ttk.Entry(frame_row, textvariable=self.EMU_PATH)
-        adb_entry.grid_remove()
+        self.adb_status_label.grid(row=0, column=2, sticky=tk.W, padx=(0, 5), pady=2)
+        row_counter += 1
+
+        self.device_paths_block = ttk.LabelFrame(container, text=_("配置"))
+        self.device_paths_block.grid(row=row_counter, column=0, sticky=tk.W, pady=(4, 2))
+
+        self.device_install_path = tk.StringVar(value="")
+        self.device_emulator_path = tk.StringVar(value="")
+        self.device_adb_tools_path = tk.StringVar(value="")
+        self.device_extra_path = tk.StringVar(value="")
+        self.device_real_paths = {}
+        self.device_missing_paths = []
+
+        self.path_rows = {}
+        for path_row, key, label_text, variable in [
+            (3, "install", _("安装目录:"), self.device_install_path),
+            (4, "emulator", _("模拟器程序:"), self.device_emulator_path),
+            (5, "adb", _("ADB工具:"), self.device_adb_tools_path),
+            (6, "cleanup_processes", _("清理进程:"), self.device_extra_path),
+        ]:
+            label = ttk.Label(self.device_paths_block, text=label_text, width=11)
+            label.grid(row=path_row, column=0, sticky=tk.W, padx=(5, 0), pady=2)
+            entry = ttk.Entry(self.device_paths_block, textvariable=variable, width=26, state="readonly")
+            entry.grid(row=path_row, column=1, sticky=tk.W, padx=5, pady=2)
+            self.path_rows[key] = {"label": label, "entry": entry, "label_text": label_text}
         
         def selectADB_PATH():
-            path = filedialog.askopenfilename(
-                title=_("选择ADB执行文件"),
-                filetypes=[("Executable", "*.exe"), ("All files", "*.*")]
-            )
+            if self.DEVICE_TYPE.get() == "gpg_dev":
+                path = filedialog.askdirectory(title=_("选择模拟器目录"))
+            else:
+                path = filedialog.askdirectory(title=_("选择模拟器安装目录"))
             if path:
                 self.EMU_PATH.set(path)
                 self.save_config()
 
         self.adb_path_change_button = ttk.Button(
-            frame_row, text=_("修改"), command=selectADB_PATH, width=5
+            self.device_paths_block, text=_("修改"), command=selectADB_PATH, width=5
         )
-        self.adb_path_change_button.grid(row=0, column=1)
+        self.adb_path_change_button.grid(row=3, column=2, sticky=tk.W, padx=(0, 0), pady=2)
+
+        def selectPHYSICAL_ADB_PATH():
+            path = filedialog.askopenfilename(
+                title=_("选择ADB执行文件"),
+                filetypes=[("Executable", "*.exe"), ("All files", "*.*")]
+            )
+            if path:
+                self.ADB_PATH.set(path)
+                self.save_config()
+
+        self.physical_adb_path_change_button = ttk.Button(
+            self.device_paths_block, text=_("修改"), command=selectPHYSICAL_ADB_PATH, width=5
+        )
+        self.physical_adb_path_change_button.grid(row=5, column=2, sticky=tk.W, padx=(0, 0), pady=2)
+
+        self.device_config_warning = ttk.Label(
+            self.device_paths_block,
+            text=_("部分必要文件未找到，请检查安装目录或ADB工具路径。"),
+            foreground="red",
+            wraplength=420,
+        )
+        self.device_config_warning.grid(row=7, column=0, columnspan=3, sticky=tk.W, padx=(5, 0), pady=(4, 2))
+        self.device_config_warning.grid_remove()
         
         def update_adb_status(*args):
-            if self.EMU_PATH.get():
-                self.adb_status_label.config(text=_("已设置模拟器"), foreground="green")
+            if self.DEVICE_TYPE.get() == "physical":
+                if self.ADB_PATH.get():
+                    self.adb_status_label.config(text=_("已设置设备"), foreground="green")
+                else:
+                    self.adb_status_label.config(text=_("未找到设备"), foreground="red")
+            elif self.EMU_PATH.get():
+                if self.DEVICE_TYPE.get() == "gpg_dev":
+                    self.adb_status_label.config(text=_("已设置模拟器目录"), foreground="green")
+                else:
+                    self.adb_status_label.config(text=_("已设置模拟器"), foreground="green")
             else:
-                self.adb_status_label.config(text=_("未设置模拟器"), foreground="red")
+                self.adb_status_label.config(text=_("未找到模拟器"), foreground="red")
+
+        def display_device_path(value, install_root=None):
+            path_text = str(value or "")
+            if not path_text or install_root is None:
+                return path_text
+            path = device_path(path_text)
+            root = device_path(install_root)
+            try:
+                relative = path.relative_to(root)
+            except ValueError:
+                return path_text
+            return "$" + _("安装目录") + "\\" + str(relative)
+
+        def set_path_row(key, value, required=True, display_value=None):
+            real_value = str(value or "")
+            display_value = str(display_value if display_value is not None else real_value)
+            self.device_real_paths[key] = real_value
+            row = self.path_rows[key]
+            row["label"].configure(text=row["label_text"], foreground="black")
+            self.path_rows[key]["entry"].configure(foreground="black")
+            if key == "install":
+                self.device_install_path.set(display_value)
+            elif key == "emulator":
+                self.device_emulator_path.set(display_value)
+            elif key == "adb":
+                self.device_adb_tools_path.set(display_value)
+            elif key == "cleanup_processes":
+                self.device_extra_path.set(display_value)
+
+            if not real_value:
+                if required:
+                    self.path_rows[key]["entry"].configure(foreground="red")
+                    row["label"].configure(foreground="red")
+                    self.device_missing_paths.append(key)
+                return
+
+            path = device_path(real_value)
+            if path_exists(path):
+                row["label"].configure(foreground="green")
+            elif required:
+                self.path_rows[key]["entry"].configure(foreground="red")
+                row["label"].configure(foreground="red")
+                self.device_missing_paths.append(key)
+
+        def update_device_config_warning():
+            if not hasattr(self, "device_config_warning"):
+                return
+            if self.device_missing_paths:
+                self.device_config_warning.grid()
+            else:
+                self.device_config_warning.grid_remove()
+
+        def apply_path_row_visibility():
+            device_cls = DEVICE_REGISTRY.get(self.DEVICE_TYPE.get())
+            visible_rows = getattr(device_cls, "visible_path_rows", []) if device_cls else []
+            for key, widgets in self.path_rows.items():
+                if key in visible_rows:
+                    widgets["label"].grid()
+                    widgets["entry"].grid()
+                else:
+                    widgets["label"].grid_remove()
+                    widgets["entry"].grid_remove()
+
+        def adb_tools_available():
+            adb_path_text = self.device_real_paths.get("adb", "")
+            return bool(adb_path_text) and path_exists(device_path(adb_path_text))
+
+        def update_adb_test_button_visibility():
+            if not hasattr(self, "button_test_adb_port"):
+                return
+            if adb_tools_available():
+                if not self.button_test_adb_port.winfo_manager():
+                    self.button_test_adb_port.pack(side=tk.LEFT)
+            else:
+                self.button_test_adb_port.pack_forget()
+
+        def test_adb_connection():
+            self.save_config()
+            adb_path_text = self.device_real_paths.get("adb", "")
+            if not adb_path_text or not path_exists(device_path(adb_path_text)):
+                messagebox.showwarning(_("ADB测试"), _("ADB工具不存在，无法测试连接。"))
+                return
+
+            adb_path = str(device_path(adb_path_text))
+            serial = self.ADB_ADRESS.get().strip()
+            try:
+                if ":" in serial:
+                    subprocess.run(
+                        [adb_path, "connect", serial],
+                        capture_output=True,
+                        text=True,
+                        timeout=8,
+                        encoding="utf-8",
+                        errors="ignore",
+                    )
+                result = subprocess.run(
+                    [adb_path, "devices"],
+                    capture_output=True,
+                    text=True,
+                    timeout=8,
+                    encoding="utf-8",
+                    errors="ignore",
+                )
+            except Exception as exc:
+                messagebox.showerror(_("ADB测试"), _("ADB测试失败: {a}").format(a=exc))
+                return
+
+            output = (result.stdout or "") + (result.stderr or "")
+            if serial and serial in output:
+                messagebox.showinfo(_("ADB测试"), _("ADB连接成功，地址已保存。"))
+            else:
+                messagebox.showwarning(_("ADB测试"), _("未在ADB设备列表中找到该地址。"))
+
+        def update_device_paths(*args):
+            emu_path = self.EMU_PATH.get()
+            self.device_install_path.set("")
+            self.device_emulator_path.set("")
+            self.device_adb_tools_path.set("")
+            self.device_extra_path.set("")
+            self.device_real_paths = {}
+            self.device_missing_paths = []
+
+            if self.DEVICE_TYPE.get() == "physical":
+                set_path_row("install", "", required=False)
+                set_path_row("emulator", "", required=False)
+                set_path_row("adb", self.ADB_PATH.get(), required=True)
+                set_path_row("cleanup_processes", "", required=False)
+                apply_path_row_visibility()
+                update_adb_test_button_visibility()
+                update_device_config_warning()
+                return
+
+            if not emu_path:
+                set_path_row("install", "", required=True)
+                set_path_row("emulator", "", required=True)
+                set_path_row("adb", "", required=True)
+                set_path_row("cleanup_processes", "", required=False)
+                apply_path_row_visibility()
+                update_adb_test_button_visibility()
+                update_device_config_warning()
+                return
+
+            root = device_path(emu_path)
+            match self.DEVICE_TYPE.get():
+                case "mumu":
+                    if root.name.lower() == "shell":
+                        root = root.parent.parent.parent
+                    shell_dir = root / "nx_device" / "12.0" / "shell"
+                    set_path_row("install", root)
+                    set_path_row(
+                        "emulator",
+                        shell_dir / "MuMuNxDevice.exe",
+                        display_value=display_device_path(shell_dir / "MuMuNxDevice.exe", root),
+                    )
+                    set_path_row(
+                        "adb",
+                        shell_dir / "adb.exe",
+                        display_value=display_device_path(shell_dir / "adb.exe", root),
+                    )
+                    set_path_row("cleanup_processes", "MuMuVMMSVC.exe, MuMuVMMHeadless.exe", required=False)
+                case "bluestacks":
+                    set_path_row("install", root)
+                    set_path_row(
+                        "emulator",
+                        root / "HD-Player.exe",
+                        display_value=display_device_path(root / "HD-Player.exe", root),
+                    )
+                    set_path_row(
+                        "adb",
+                        root / "HD-Adb.exe",
+                        display_value=display_device_path(root / "HD-Adb.exe", root),
+                    )
+                    set_path_row("cleanup_processes", "", required=False)
+                case "gpg_dev":
+                    if root.name.lower() == "emulator":
+                        root = root.parent.parent
+                    emulator_dir = root / "current" / "emulator"
+                    set_path_row("install", root)
+                    set_path_row(
+                        "emulator",
+                        root / "Bootstrapper.exe",
+                        display_value=display_device_path(root / "Bootstrapper.exe", root),
+                    )
+                    set_path_row(
+                        "adb",
+                        emulator_dir / "adb.exe",
+                        display_value=display_device_path(emulator_dir / "adb.exe", root),
+                    )
+                    set_path_row("cleanup_processes", "", required=False)
+                case _:
+                    set_path_row("install", "", required=False)
+                    set_path_row("emulator", "", required=False)
+                    set_path_row("adb", "", required=False)
+                    set_path_row("cleanup_processes", "", required=False)
+
+            apply_path_row_visibility()
+            update_adb_test_button_visibility()
+            update_device_config_warning()
+
+        def detect_default_emulator_path(device_type):
+            device_cls = DEVICE_REGISTRY.get(device_type)
+            if not device_cls:
+                return None
+            for root in getattr(device_cls, "default_install_roots", []):
+                path = device_path(root)
+                if path_exists(path):
+                    return str(path)
+            return None
+
+        def detect_default_adb_path(device_type):
+            device_cls = DEVICE_REGISTRY.get(device_type)
+            if not device_cls:
+                return None
+            first_existing_default_adb_path = getattr(device_cls, "first_existing_default_adb_path", None)
+            if not first_existing_default_adb_path:
+                return None
+            path = first_existing_default_adb_path()
+            return str(path) if path else None
         
         self.EMU_PATH.trace_add("write", lambda *args: update_adb_status())
+        self.EMU_PATH.trace_add("write", lambda *args: update_device_paths())
+        self.ADB_PATH.trace_add("write", lambda *args: update_adb_status())
+        self.ADB_PATH.trace_add("write", lambda *args: update_device_paths())
         update_adb_status()
+        update_device_paths()
 
-        # 端口和编号
-        row_counter += 1
-        frame_row = ttk.Frame(container)
-        frame_row.grid(row=row_counter, column=0, sticky="ew", pady=2)
-        ttk.Label(frame_row, text=_("ADB地址:")).grid(row=0, column=2, sticky=tk.W, pady=5)
+        self.adb_address_label = ttk.Label(self.device_paths_block, text=_("ADB地址:"), width=11)
+        self.adb_address_label.grid(row=1, column=0, sticky=tk.W, padx=(5, 0), pady=2)
         vcmd_non_neg = self.register(lambda x: ((x=="")or(x.isdigit())))
-        self.adb_port_entry = ttk.Entry(frame_row, textvariable=self.ADB_ADRESS, validate="key",
-                                        width=15)
-        self.adb_port_entry.grid(row=0, column=3)
-        self.button_save_adb_port = ttk.Button(frame_row, text=_("保存"), command=self.save_config, width=5)
-        self.button_save_adb_port.grid(row=0, column=4)
-        row_counter += 1
-        frame_row = ttk.Frame(container)
-        frame_row.grid(row=row_counter, column=0, sticky="ew", pady=2)
-        ttk.Label(frame_row, text=_("模拟器编号:")).grid(row=0, column=0, sticky=tk.W, pady=5)
-        self.emu_index_entry = ttk.Entry(frame_row, textvariable=self.EMU_INDEX, validate="key",
+        self.adb_port_entry = ttk.Entry(self.device_paths_block, textvariable=self.ADB_ADRESS, validate="key",
+                                        width=26)
+        self.adb_port_entry.grid(row=1, column=1, sticky=tk.W, padx=5, pady=2)
+        self.adb_address_actions = ttk.Frame(self.device_paths_block)
+        self.adb_address_actions.grid(row=1, column=2, sticky=tk.W, padx=(0, 0), pady=2)
+        self.button_test_adb_port = ttk.Button(self.adb_address_actions, text=_("测试"), command=test_adb_connection, width=5)
+        self.button_test_adb_port.pack(side=tk.LEFT)
+
+        self.emu_index_label = ttk.Label(self.device_paths_block, text=_("多开编号:"), width=11)
+        self.emu_index_label.grid(row=2, column=0, sticky=tk.W, padx=(5, 0), pady=2)
+        self.emu_index_entry = ttk.Entry(self.device_paths_block, textvariable=self.EMU_INDEX, validate="key",
                                          validatecommand=(vcmd_non_neg, '%P'), width=5)
-        self.emu_index_entry.grid(row=0, column=1)
-        self.button_save_emu_index = ttk.Button(frame_row, text=_("保存"), command=self.save_config, width=5)
-        self.button_save_emu_index.grid(row=0, column=2)
+        self.emu_index_entry.grid(row=2, column=1, sticky=tk.W, padx=5, pady=2)
+        self.button_save_emu_index = ttk.Button(self.device_paths_block, text=_("保存"), command=self.save_config, width=5)
+        self.button_save_emu_index.grid(row=2, column=2, sticky=tk.W, padx=(0, 0), pady=2)
+
+        def on_device_type_change(save=False):
+            self.DEVICE_TYPE.set(self.DEVICE_TYPE_OPTIONS.get(self.device_type_display.get(), "mumu"))
+            device_type = self.DEVICE_TYPE.get()
+            device_cls = DEVICE_REGISTRY.get(device_type)
+            visible_fields = getattr(device_cls, "visible_config_fields", [])
+            if "emu_path" in visible_fields:
+                self.adb_path_change_button.grid()
+            else:
+                self.adb_path_change_button.grid_remove()
+            if "adb_path" in visible_fields:
+                self.physical_adb_path_change_button.grid()
+            else:
+                self.physical_adb_path_change_button.grid_remove()
+
+            if "emu_index" in visible_fields:
+                self.emu_index_label.grid()
+                self.emu_index_entry.grid()
+                self.button_save_emu_index.grid()
+            else:
+                self.emu_index_label.grid_remove()
+                self.emu_index_entry.grid_remove()
+                self.button_save_emu_index.grid_remove()
+
+            self.adb_address_label.config(text=getattr(device_cls, "address_label", _("ADB地址:")))
+            default_adb_address = getattr(device_cls, "default_adb_address", "")
+            if save and default_adb_address:
+                self.ADB_ADRESS.set(default_adb_address)
+
+            if "emu_path" in visible_fields:
+                default_path = detect_default_emulator_path(device_type)
+                if save:
+                    self.EMU_PATH.set(default_path or "")
+                elif default_path and not self.EMU_PATH.get():
+                    self.EMU_PATH.set(default_path)
+            if "adb_path" in visible_fields:
+                default_path = detect_default_adb_path(device_type)
+                if save:
+                    self.ADB_PATH.set(default_path or "")
+                elif default_path and not self.ADB_PATH.get():
+                    self.ADB_PATH.set(default_path)
+            update_adb_status()
+            update_device_paths()
+            update_adb_test_button_visibility()
+            if save:
+                self.save_config()
+
+        self.device_type_combobox.bind("<<ComboboxSelected>>", lambda e: on_device_type_change(save=True))
+        on_device_type_change()
 
 
         # ==========================================
@@ -1514,7 +1883,9 @@ class ConfigPanelApp(tk.Toplevel):
 
     def set_controls_state(self, state):
         Button_and_Entry = [
+            self.device_type_combobox,
             self.adb_path_change_button,
+            self.physical_adb_path_change_button,
             self.random_chest_check,
             self.who_will_open_combobox,
             self.skip_recover_check,
@@ -1531,7 +1902,7 @@ class ConfigPanelApp(tk.Toplevel):
             self.active_royalsuite_rest,
             self.active_beg_money,
             self.task_specific_config_check,
-            self.button_save_adb_port,
+            self.button_test_adb_port,
             self.button_save_emu_index,
             self.delete_task_specific_config_button,
             self.active_csc,
@@ -1565,6 +1936,8 @@ class ConfigPanelApp(tk.Toplevel):
             self.updateACTIVE_REST_state()
 
     def toggle_start_stop(self):
+        if self.quest_stopping:
+            return
         if not self.quest_active:
             self.start_stop_btn.config(text="停止")
             self.set_controls_state(tk.DISABLED)
@@ -1572,12 +1945,15 @@ class ConfigPanelApp(tk.Toplevel):
             setting._FINISHINGCALLBACK = self.finishingcallback
             self.msg_queue.put(('start_quest', setting))
             self.quest_active = True
+            self.quest_stopping = False
         else:
+            self.quest_stopping = True
+            self.start_stop_btn.config(text=_("停止中..."), state=tk.DISABLED)
             self.msg_queue.put(('stop_quest', None))
 
     def finishingcallback(self):
         logger.info(_("已停止."))
-        self.start_stop_btn.config(text=_("脚本, 启动!"))
+        self.start_stop_btn.config(text=_("脚本, 启动!"), state=tk.NORMAL)
         self.set_controls_state(tk.NORMAL)
         
         config = LoadConfig()
@@ -1585,6 +1961,7 @@ class ConfigPanelApp(tk.Toplevel):
             self.KARMA_ADJUST.set(config['KARMA_ADJUST'])
 
         self.quest_active = False
+        self.quest_stopping = False
 
     def turn_to_7000G(self):
         self.summary_log_display.config(bg="#F4C6DB" )

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,8 @@
 from gui import *
 import argparse
+import os
+import signal
+import threading
 
 __version__ = '2.2.8' 
 OWNER = "arnold2957"
@@ -11,6 +14,7 @@ class AppController(tk.Tk):
         self.withdraw()
         self.msg_queue = queue.Queue()
         self.main_window = None
+        self._shutting_down = False
         if not headless:
             if not self.main_window:
                 self.main_window = ConfigPanelApp(self,
@@ -22,6 +26,7 @@ class AppController(tk.Tk):
             
         self.quest_threading = None
         self.quest_setting = None
+        self._display_restored = False
 
         self.is_checking_for_update = False 
         self.updater = AutoUpdater(
@@ -32,6 +37,40 @@ class AppController(tk.Tk):
         )
         self.schedule_periodic_update_check()
         self.check_queue()
+
+    def force_shutdown(self, signum=None, frame=None, exit_code=130):
+        if self._shutting_down:
+            return
+        self._shutting_down = True
+
+        def fallback_exit():
+            os._exit(exit_code)
+
+        fallback_timer = threading.Timer(30.0, fallback_exit)
+        fallback_timer.daemon = True
+        fallback_timer.start()
+
+        try:
+            logger.info("正在强制停止程序...")
+            if self.quest_setting and hasattr(self.quest_setting, '_FORCESTOPING'):
+                self.quest_setting._FORCESTOPING.set()
+                self.cleanup_device_after_stop()
+            if self.main_window and self.main_window.winfo_exists():
+                try:
+                    self.main_window.destroy()
+                except Exception:
+                    pass
+            try:
+                self.quit()
+            except Exception:
+                pass
+            try:
+                self.destroy()
+            except Exception:
+                pass
+            StopLogListener()
+        except Exception:
+            os._exit(exit_code)
 
     def run_in_thread(self, target_func, *args):
         thread = threading.Thread(target=target_func, args=args, daemon=True)
@@ -60,8 +99,10 @@ class AppController(tk.Tk):
                     self.quest_setting = value                    
                     self.quest_setting._MSGQUEUE = self.msg_queue
                     self.quest_setting._FORCESTOPING = Event()
+                    self._display_restored = False
                     Farm = Factory()
                     self.quest_threading = Thread(target=Farm,args=(self.quest_setting,))
+                    self.quest_threading.daemon = True
                     self.quest_threading.start()
                     logger.info(f'启动任务\"{self.quest_setting.FARM_TARGET_TEXT}\"...')
 
@@ -70,6 +111,7 @@ class AppController(tk.Tk):
                     if hasattr(self, 'quest_threading') and self.quest_threading.is_alive():
                         if hasattr(self.quest_setting, '_FORCESTOPING'):
                             self.quest_setting._FORCESTOPING.set()
+                        self.cleanup_device_after_stop()
                 
                 case 'turn_to_7000G':
                     logger.info('开始要钱...')
@@ -79,6 +121,7 @@ class AppController(tk.Tk):
                         if not self.quest_threading.is_alive():
                             Farm = Factory()
                             self.quest_threading = Thread(target=Farm,args=(self.quest_setting,))
+                            self.quest_threading.daemon = True
                             self.quest_threading.start()
                             break
                     if self.main_window:
@@ -146,7 +189,20 @@ class AppController(tk.Tk):
             pass
         finally:
             # 持续监听
-            self.after(100, self.check_queue)
+            if not self._shutting_down:
+                self.after(100, self.check_queue)
+
+    def cleanup_device_after_stop(self):
+        if self._display_restored:
+            return
+        device = getattr(self.quest_setting, "_DEVICE", None) if self.quest_setting else None
+        if not device:
+            return
+        try:
+            if device.cleanup_after_stop():
+                self._display_restored = True
+        except Exception as e:
+            logger.error(_("停止后清理设备时出错: {a}").format(a=e))
 
 def parse_args():
     """解析命令行参数"""
@@ -175,7 +231,13 @@ def main():
     args = parse_args()
 
     controller = AppController(args.headless, args.config)
-    controller.mainloop()
+    signal.signal(signal.SIGINT, controller.force_shutdown)
+    try:
+        controller.mainloop()
+    except KeyboardInterrupt:
+        controller.force_shutdown()
+    finally:
+        StopLogListener()
 
 def HeadlessActive(config_path,msg_queue):
     RegisterConsoleHandler()

--- a/src/script.py
+++ b/src/script.py
@@ -1,4 +1,3 @@
-from ppadb.client import Client as AdbClient
 from win10toast import ToastNotifier
 from scipy.optimize import curve_fit
 from scipy.signal import find_peaks
@@ -7,6 +6,7 @@ from datetime import datetime
 import os
 import subprocess
 from utils import *
+from device import create_device
 import random
 from threading import Thread,Event
 from pathlib import Path
@@ -20,9 +20,11 @@ DUNGEON_TARGETS = BuildQuestReflection()
         
 CONFIG_VAR_LIST = [
             #categor      var_name,                   type,          default_value
+            ["GENERAL",   "DEVICE_TYPE",              tk.StringVar,  "mumu"],
             ["GENERAL",   "EMU_PATH",                 tk.StringVar,  None],
             ["GENERAL",   "EMU_INDEX",                tk.IntVar,     0],
             ["GENERAL",   "ADB_ADRESS",               tk.StringVar,  "127.0.0.1:16384"],
+            ["GENERAL",   "ADB_PATH",                 tk.StringVar,  None],
             ["GENERAL",   "LAST_VERSION",             tk.StringVar,  None],
             ["GENERAL",   "LATEST_VERSION",           tk.StringVar,  None],
             ["GENERAL",   "FARM_TARGET_TEXT",         tk.StringVar,  list(DUNGEON_TARGETS.keys())[0] if DUNGEON_TARGETS else ""],
@@ -76,6 +78,7 @@ class FarmConfig:
         self._MSGQUEUE = None
         #### 底层接口
         self._ADBDEVICE = None
+        self._DEVICE = None
     def __getitem__(self, key):
         return getattr(self, key)
     def __getattr__(self, name):
@@ -204,271 +207,6 @@ def CMDLine(cmd):
     result = subprocess.run(cmd,shell=True, capture_output=True, text=True, timeout=10,encoding="utf-8")
     logger.debug(_("cmd命令返回:{a}\n cmd命令错误:{b}").format(a=result.stdout, b=result.stderr))
     return result
-def GetADBPathFromEmuPath(emu_path):
-        adb_path = emu_path
-        adb_path = adb_path.replace("HD-Player.exe", "HD-Adb.exe") # 蓝叠
-        adb_path = adb_path.replace("MuMuPlayer.exe", "adb.exe") # mumu
-        adb_path = adb_path.replace("MuMuNxDevice.exe", "adb.exe") # mumu
-        if not os.path.exists(adb_path):
-            logger.error(_("adb程序序不存在: {a}").format(a=adb_path))
-            return None
-    
-        return adb_path
-def CheckAndRecoverDevice(setting : FarmConfig, runtimeContext: RuntimeContext, FORCE_RESTART_EMU = False, FORCE_RESTART_ADB = False):
-    def CheckEmulator():
-        result = subprocess.run(
-            "tasklist /FO CSV /NH | findstr \"MuMuNxDevice.exe MuMuPlayer.exe\"",
-            shell=True,
-            capture_output=True, 
-            text=True
-        )
-        result_str = result.stdout.strip()
-        logger.debug(result_str)
-        split_results_list = result_str.split("\n")
-        check_results_list = []
-        for task in split_results_list:
-            if not task:
-                continue
-            parts = task.split("\",\"")
-            if len(parts) >= 2:
-                try:
-                    pid = int(parts[1])
-                    check_results_list.append(pid)
-                except ValueError:
-                    pass
-        return check_results_list
-    def KillAdb():
-        adb_path = GetADBPathFromEmuPath(setting.EMU_PATH)
-        try:
-            logger.info(_("正在检查并关闭adb..."))
-            # Windows 系统使用 taskkill 命令
-            if os.name == "nt":
-                subprocess.run(
-                    f"taskkill /f /im adb.exe", 
-                    shell=True,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    check=False  # 不检查命令是否成功（进程可能不存在）
-                )
-                time.sleep(1)
-                subprocess.run(
-                    f"taskkill /f /im HD-Adb.exe", 
-                    shell=True,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    check=False  # 不检查命令是否成功（进程可能不存在）
-                )
-            else:
-                subprocess.run(
-                    f"pkill -f {adb_path}", 
-                    shell=True,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    check=False
-                )
-            logger.info(_("已尝试终止adb"))
-        except Exception as e:
-            logger.error(_("终止模拟器进程时出错: {a}").format(a=str(e)))
-    def KillEmulator():
-        emulator_name = os.path.basename(setting.EMU_PATH)
-        emulator_SVC = "MuMuVMMSVC.exe"
-        try:
-            logger.info(_("正在检查并关闭已运行的模拟器实例{a}...").format(a=emulator_name))
-            # Windows 系统使用 taskkill 命令
-            if os.name == "nt":
-                if runtimeContext._RUNNING_EMU_PID:
-                    logger.info(_("使用已知进程号{a}关闭模拟器...").format(a=runtimeContext._RUNNING_EMU_PID))
-                    subprocess.run(
-                        f"taskkill /IM /pid {runtimeContext._RUNNING_EMU_PID}", 
-                        shell=True,
-                        stdout=subprocess.DEVNULL,
-                        stderr=subprocess.DEVNULL,
-                        check=False  # 不检查命令是否成功（进程可能不存在）
-                    )
-                    time.sleep(1)
-                    subprocess.run(
-                        f"taskkill /F /IM MuMuVMMHeadless.exe", 
-                        shell=True,
-                        stdout=subprocess.DEVNULL,
-                        stderr=subprocess.DEVNULL,
-                        check=False  # 不检查命令是否成功（进程可能不存在）
-                    )
-                    time.sleep(1)
-                else:
-                    logger.info(_("模拟器uid未知, 全杀了."))
-                    subprocess.run(
-                        f"taskkill /f /im {emulator_name}", 
-                        shell=True,
-                        stdout=subprocess.DEVNULL,
-                        stderr=subprocess.DEVNULL,
-                        check=False  # 不检查命令是否成功（进程可能不存在）
-                    )
-                    time.sleep(1)
-                    subprocess.run(
-                        f"taskkill /f /im {emulator_SVC}", 
-                        shell=True,
-                        stdout=subprocess.DEVNULL,
-                        stderr=subprocess.DEVNULL,
-                        check=False  # 不检查命令是否成功（进程可能不存在）
-                    )
-                    time.sleep(1)
-
-            # Unix/Linux 系统使用 pkill 命令
-            else:
-                subprocess.run(
-                    f"pkill -f {emulator_name}", 
-                    shell=True,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    check=False
-                )
-                subprocess.run(
-                    f"pkill -f {emulator_headless}", 
-                    shell=True,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    check=False
-                )
-            logger.info(_("已尝试终止模拟器进程: {a}".format(a=emulator_name)))
-        except Exception as e:
-            logger.error(_("终止模拟器进程时出错: {a}".format(a=str(e))))
-        finally:
-            # 重置进程号
-            runtimeContext._RUNNING_EMU_PID = None
-
-    def StartEmulator():
-        hd_player_path = setting.EMU_PATH
-        if not os.path.exists(hd_player_path):
-            logger.error(_("模拟器启动程序不存在: {a}".format(a=hd_player_path)))
-            return False
-        
-        cmd = ("\"{hd}\" control -v {a}").format(hd=hd_player_path, a=setting.EMU_INDEX)
-        try:
-            logger.info(_("启动模拟器: {a}".format(a=cmd)))
-
-            # 启动前检查进程
-            pre_result_list = CheckEmulator()
-
-            subprocess.Popen(
-                cmd, 
-                shell=True,
-                stdout=subprocess.DEVNULL, 
-                stderr=subprocess.DEVNULL,
-                cwd=os.path.dirname(hd_player_path))
-
-            # 延时
-            time.sleep(5)
-
-            # 启动后检查进程
-            aft_results_list = CheckEmulator()
-
-            logger.info(aft_results_list)
-            new_tasks = [task for task in aft_results_list if task not in pre_result_list]
-            if new_tasks:
-                # 模拟器启动成功，pid捕获成功
-                runtimeContext._RUNNING_EMU_PID = int(new_tasks[0])
-                logger.info(_("模拟器启动开始，进程号为{a}".format(a=runtimeContext._RUNNING_EMU_PID)))
-
-        except Exception as e:
-            logger.error(_("启动模拟器失败: {a}".format(a=str(e))))
-            return False
-        
-        logger.info(_("等待模拟器启动..."))
-        time.sleep(15)
-
-    # 以上是内部函数
-    ####################################
-    # 功能实现
-
-    if FORCE_RESTART_EMU:
-        KillEmulator()
-        time.sleep(1)
-    
-    if FORCE_RESTART_ADB:
-        KillAdb()
-        time.sleep(1)
-
-    MAXRETRIES = 20
-
-    adb_path = GetADBPathFromEmuPath(setting.EMU_PATH)
-
-    for attempt in range(MAXRETRIES):
-        logger.info(_("-----------------------\n开始尝试连接adb. 次数:{a}/{b}...").format(a=attempt + 1, b=MAXRETRIES))
-
-        if attempt == 3:
-            logger.info(_("失败次数过多, 尝试关闭adb."))
-            KillAdb()
-
-            # 我们不起手就关, 但是如果2次链接还是尝试失败, 那就触发一次强制重启.
-        
-        try:
-            logger.info(_("检查adb服务..."))
-            result = CMDLine(f"\"{adb_path}\" devices")
-            if ("daemon not running" in result.stderr) or ("offline" in result.stdout):
-                time.sleep(2)
-                result = CMDLine(f"\"{adb_path}\" devices")
-                if ("daemon not running" in result.stderr) or ("offline" in result.stdout):
-                    logger.info("adb服务未启动!\n启动adb服务...")
-                    CMDLine(f"\"{adb_path}\" kill-server")
-                    CMDLine(f"\"{adb_path}\" start-server")
-                    time.sleep(2)
-
-            logger.debug(_("尝试连接到adb..."))
-            result = CMDLine(f"\"{adb_path}\" connect {setting.ADB_ADRESS}")
-
-            result = CMDLine(f"\"{adb_path}\" devices")
-            if ("{a}").format(a=setting.ADB_ADRESS) in result.stdout:
-                logger.info(_("成功连接到模拟器!"))
-                results_list = CheckEmulator()
-                logger.debug("{a}".format(a=results_list))
-                if len(results_list)==1:
-                    runtimeContext._RUNNING_EMU_PID = int(results_list[0])
-                    logger.info(_("模拟器进程号为{a}.".format(a=runtimeContext._RUNNING_EMU_PID)))
-                else:
-                    logger.info(_("\n\n***********\n有多个模拟器已经启动, 无法识别进程号. 当需要重启模拟器的时候, 会重启所有模拟器.\n为了避免此问题, 请关闭目标模拟器, 并使用本脚本自动启动模拟器.\n\n"))
-                break
-
-            if (not runtimeContext._RUNNING_EMU_PID) or (runtimeContext._RUNNING_EMU_PID not in CheckEmulator()):
-                logger.info(_("模拟器未运行，尝试启动..."))
-                StartEmulator()
-                logger.info(_("模拟器(应该)启动完毕.\n 尝试连接到模拟器..."))
-                result = CMDLine(f"\"{adb_path}\" connect {setting.ADB_ADRESS}")
-                if result.returncode == 0 and ("connected" in result.stdout or "already" in result.stdout):
-                    logger.info(_("成功连接到模拟器"))
-                    break
-                logger.info(_("无法连接. 检查adb端口."))
-
-            logger.info(_("连接失败: {a}".format(a=result.stderr.strip())))
-            time.sleep(2)
-            KillEmulator()
-            KillAdb()
-            time.sleep(2)
-        except Exception as e:
-            logger.error(_("重启ADB服务时出错: {a}".format(a=e)))
-            time.sleep(2)
-            KillEmulator()
-            KillAdb()
-            time.sleep(2)
-            return None
-    else:
-        logger.info(_("达到最大重试次数，连接失败"))
-        return None
-
-    try:
-        client = AdbClient(host="127.0.0.1", port=5037)
-        devices = client.devices()
-        
-        # 查找匹配的设备
-        target_device = "{a}".format(a=setting.ADB_ADRESS)
-        for device in devices:
-            if device.serial == target_device:
-                logger.info(_("成功创建设备对象: {a}".format(a=device.serial)))
-                return device
-    except Exception as e:
-        logger.error(_("创建ADB设备时出错: {a}".format(a=e)))
-    
-    return None
-##################################################################
 def CutRoI(screenshot, roi):
     """
     screenshot: 输入图像
@@ -519,7 +257,12 @@ def Factory():
     def ResetDevice(force_restart_emu=False, force_restart_adb = False):
         nonlocal setting # 修改device
         nonlocal runtimeContext
-        if device := CheckAndRecoverDevice(setting, runtimeContext, force_restart_emu, force_restart_adb):
+        if setting._FORCESTOPING and setting._FORCESTOPING.is_set():
+            logger.info(_("任务正在停止，跳过设备重连."))
+            return None
+        if setting._DEVICE is None:
+            setting._DEVICE = create_device(setting, runtimeContext)
+        if device := setting._DEVICE.connect(force_restart_emu, force_restart_adb):
             setting._ADBDEVICE = device
             logger.info(_("ADB服务成功启动，设备已连接."))
     def DeviceShell(cmdStr):
@@ -532,7 +275,7 @@ def Factory():
             def adb_command_thread():
                 nonlocal exception, result
                 try:
-                    result = setting._ADBDEVICE.shell(cmdStr, timeout=5)
+                    result = setting._DEVICE.shell(cmdStr, timeout=5)
                 except Exception as e:
                     exception = e
                 finally:
@@ -578,14 +321,7 @@ def Factory():
         
         while True:
             try:
-                # 获取设备序列号，用于构造 adb 命令
-                serial = setting._ADBDEVICE.serial 
-
-                process_result = subprocess.run(
-                    [GetADBPathFromEmuPath(setting.EMU_PATH), "-s", serial, "exec-out", "screencap"],
-                    capture_output=True, # 捕获输出
-                    timeout=5            # 设置超时
-                )
+                process_result = setting._DEVICE.screencap()
                 
                 if process_result.stderr:
                     logger.error(_("截图命令报错: {a}".format(a=process_result.stderr.decode('utf-8', errors='ignore'))))
@@ -949,16 +685,14 @@ def Factory():
             force_restart_EMU = True
 
         if force_restart_EMU:
-            CheckAndRecoverDevice(setting, runtimeContext, FORCE_RESTART_EMU=True)
+            if setting._DEVICE is None:
+                setting._DEVICE = create_device(setting, runtimeContext)
+            setting._DEVICE.connect(force_restart_emu=True)
             Sleep(5)
 
-        DeviceShell("logcat -c")
-        mainAct = DeviceShell(f"cmd package resolve-activity --brief {package_name}").strip().split("\n")[-1]
-        DeviceShell(f"am force-stop {package_name}")
-        logger.info(_("巫术, 启动!"))
-        logger.debug(DeviceShell(f"am start -n {mainAct}"))
+        setting._DEVICE.restart_game(package_name)
         Sleep(10)
-        logs = DeviceShell("logcat -d | grep -i \"unable to initialize.*graphics api\"")
+        logs = setting._DEVICE.find_graphics_api_crash_log()
         if logs.strip():
             logger.error(_("检测到崩溃日志, 关闭模拟器重启.{a}".format(a=logs)))
             restartGame(skip_screenshot = False, force_restart_EMU = True)
@@ -967,11 +701,20 @@ def Factory():
         pass
     def RestartableSequenceExecution(*operations):
         while True:
+            if setting._FORCESTOPING.is_set():
+                logger.info(_("任务已停止."))
+                return
             try:
                 for op in operations:
+                    if setting._FORCESTOPING.is_set():
+                        logger.info(_("任务已停止."))
+                        return
                     op()
                 return
             except RestartSignal:
+                if setting._FORCESTOPING.is_set():
+                    logger.info(_("任务已停止."))
+                    return
                 logger.info(_("任务进度重置中..."))
                 continue
     ##################################################################
@@ -3135,9 +2878,13 @@ def Factory():
                 logger.info(_("开始睡觉."))
                 t = time.time()
                 for counter in range(9999):
+                    if setting._FORCESTOPING.is_set():
+                        break
                     RestartableSequenceExecution(
                             lambda:StateInn()
                             )
+                    if setting._FORCESTOPING.is_set():
+                        break
                     logger.info(_("完成了{a}次旅店休息.\n总计用时{c:.2f}s.\n平均用时{d:.2f}s.").format(a=counter+1, c=time.time()-t, d=(time.time()-t)/(counter+1)),extra={"summary": True})
             case "retard_tapjoy":
                 def split_image(img):
@@ -3159,6 +2906,8 @@ def Factory():
                 merge_counter = 0
                 start_time = time.time()
                 while 1:
+                    if setting._FORCESTOPING.is_set():
+                        break
                     Sleep(1)
                     img = ScreenShot()
                     if Press(CheckIf(img,"smallgame/nothanks")):
@@ -3265,6 +3014,11 @@ def Factory():
         Sleep(1) # 没有等utils初始化完成
         
         ResetDevice()
+        if setting._DEVICE and setting._ADBDEVICE:
+            setting._DEVICE.restart_game()
+            Sleep(10)
+        else:
+            logger.info(_("ADB设备尚未连接，跳过启动时重启游戏."))
 
         quest = LoadQuest(setting.FARM_TARGET)
         if quest:

--- a/src/utils.py
+++ b/src/utils.py
@@ -7,10 +7,10 @@ import logging.handlers
 import sys
 import cv2
 import time
-import multiprocessing
 import numpy as np
 import glob
 import gettext
+import queue
 
 # 基础模块包括:
 # LOGGER. 将输入写入到logger.txt文件中.
@@ -50,11 +50,28 @@ def setup_file_handler():
     file_handler.setFormatter(file_formatter)
     return file_handler
 
-log_queue = multiprocessing.Queue(-1)
-queue_listener = logging.handlers.QueueListener(log_queue, setup_file_handler())
+log_queue = queue.Queue(-1)
+queue_listener = None
+_log_listener_started = False
 
 def StartLogListener():
+    global queue_listener, _log_listener_started
+    if _log_listener_started:
+        return
+    queue_listener = logging.handlers.QueueListener(log_queue, setup_file_handler())
     queue_listener.start()
+    _log_listener_started = True
+
+def StopLogListener():
+    global queue_listener, _log_listener_started
+    if not _log_listener_started:
+        return
+    listener = queue_listener
+    queue_listener.stop()
+    for handler in listener.handlers:
+        handler.close()
+    queue_listener = None
+    _log_listener_started = False
 #===========================================
 class LoggerStream:
     """自定义流，将输出重定向到logger"""
@@ -83,6 +100,10 @@ def RegisterQueueHandler():
     sys.stdout = LoggerStream(logger, logging.DEBUG)
     sys.stderr = LoggerStream(logger, logging.ERROR)
     
+    for handler in logger.handlers:
+        if isinstance(handler, logging.handlers.QueueHandler) and handler.queue is log_queue:
+            return
+
     # 创建QueueHandler并连接到全局队列
     queue_handler = logging.handlers.QueueHandler(log_queue)
     queue_handler.setLevel(logging.DEBUG)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,0 +1,579 @@
+import sys
+import tempfile
+import unittest
+from pathlib import Path, PureWindowsPath
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from device import (  # noqa: E402
+    BlueStacksEmulatorDevice,
+    EmulatorDevice,
+    GooglePlayGamesDevEmulatorDevice,
+    MuMuEmulatorDevice,
+    PhysicalAndroidDevice,
+    create_device,
+    infer_device_type,
+)
+
+
+class Setting:
+    DEVICE_TYPE = "mumu"
+    EMU_PATH = ""
+    EMU_INDEX = 0
+    ADB_ADRESS = "127.0.0.1:16384"
+    ADB_PATH = ""
+    _ADBDEVICE = None
+
+
+class Runtime:
+    _RUNNING_EMU_PID = None
+
+
+class DevicePathTests(unittest.TestCase):
+    def make_device(self, device_type, emu_path="", adb_path=""):
+        setting = Setting()
+        setting.DEVICE_TYPE = device_type
+        setting.EMU_PATH = emu_path
+        setting.ADB_PATH = adb_path
+        return create_device(setting, Runtime())
+
+    def test_registry_creates_expected_device_types(self):
+        self.assertIsInstance(self.make_device("mumu", r"C:\MuMu\shell"), MuMuEmulatorDevice)
+        self.assertIsInstance(self.make_device("bluestacks", r"C:\BlueStacks"), BlueStacksEmulatorDevice)
+        self.assertIsInstance(self.make_device("gpg_dev", r"C:\GPG\current\emulator"), GooglePlayGamesDevEmulatorDevice)
+        self.assertIsInstance(self.make_device("physical", adb_path=r"C:\adb\adb.exe"), PhysicalAndroidDevice)
+
+    def test_mumu_paths_are_relative_to_install_root(self):
+        device = self.make_device("mumu", r"C:\Program Files\Netease\MuMuPlayer")
+        root = PureWindowsPath(r"C:\Program Files\Netease\MuMuPlayer")
+        shell = root / "nx_device" / "12.0" / "shell"
+        self.assertEqual(device.install_root, root)
+        self.assertEqual(device.shell_dir, shell)
+        self.assertEqual(device.adb_path, shell / "adb.exe")
+        self.assertIn(device.emu_path.name, ["MuMuNxDevice.exe", "MuMuPlayer.exe"])
+        self.assertEqual(device.emu_path.parent, shell)
+
+    def test_mumu_accepts_legacy_executable_path(self):
+        device = self.make_device("mumu", r"C:\Program Files\Netease\MuMuPlayer\nx_device\12.0\shell\MuMuNxDevice.exe")
+        root = PureWindowsPath(r"C:\Program Files\Netease\MuMuPlayer")
+        self.assertEqual(device.install_root, root)
+        self.assertEqual(device.adb_path, root / "nx_device" / "12.0" / "shell" / "adb.exe")
+
+    def test_bluestacks_paths_are_relative_to_install_root(self):
+        device = self.make_device("bluestacks", r"C:\Program Files\BlueStacks_nxt")
+        root = PureWindowsPath(r"C:\Program Files\BlueStacks_nxt")
+        self.assertEqual(device.install_root, root)
+        self.assertEqual(device.emu_path, root / "HD-Player.exe")
+        self.assertEqual(device.adb_path, root / "HD-Adb.exe")
+
+    def test_bluestacks_accepts_legacy_executable_path(self):
+        device = self.make_device("bluestacks", r"C:\BlueStacks\HD-Adb.exe")
+        root = PureWindowsPath(r"C:\BlueStacks")
+        self.assertEqual(device.install_root, root)
+        self.assertEqual(device.emu_path, root / "HD-Player.exe")
+        self.assertEqual(device.adb_path, root / "HD-Adb.exe")
+
+    def test_gpg_dev_paths_are_relative_to_emulator_root(self):
+        root = PureWindowsPath(r"C:\Program Files\Google\Play Games Developer Emulator")
+        emulator = root / "current" / "emulator"
+        device = self.make_device("gpg_dev", str(root))
+        self.assertEqual(device.install_root, root)
+        self.assertEqual(device.base_dir, emulator)
+        self.assertEqual(device.adb_path, emulator / "adb.exe")
+        self.assertEqual(device.emu_path, root / "current" / "service" / "Service.exe")
+        self.assertEqual(device.startup_bin, root / "Bootstrapper.exe")
+        self.assertEqual(device.default_adb_address, "localhost:6520")
+
+    def test_gpg_dev_multiple_crosvm_processes_are_single_emulator(self):
+        device = self.make_device("gpg_dev", r"C:\GPG")
+        with patch.object(device, "detect_running_pids", return_value=[101, 102, 103]):
+            device.capture_running_pid()
+        self.assertIsNone(device.runtime_context._RUNNING_EMU_PID)
+        with patch.object(device, "detect_running_pids", return_value=[101, 102, 103]):
+            self.assertTrue(device.is_running())
+
+    def test_gpg_dev_accepts_bundled_binary_path(self):
+        device = self.make_device("gpg_dev", r"C:\GPG\current\emulator\adb.exe")
+        root = PureWindowsPath(r"C:\GPG")
+        emulator = root / "current" / "emulator"
+        self.assertEqual(device.install_root, root)
+        self.assertEqual(device.base_dir, emulator)
+        self.assertEqual(device.adb_path, emulator / "adb.exe")
+
+    def test_physical_uses_explicit_adb_path(self):
+        device = self.make_device("physical", adb_path=r"C:\Android\platform-tools\adb.exe")
+        self.assertEqual(device.adb_path, PureWindowsPath(r"C:\Android\platform-tools\adb.exe"))
+
+    def test_physical_uses_existing_default_adb_path(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            adb_path = Path(temp_dir) / "platform-tools" / "adb.exe"
+            adb_path.parent.mkdir(parents=True)
+            adb_path.touch()
+            setting = Setting()
+            setting.DEVICE_TYPE = "physical"
+            setting.ADB_PATH = ""
+            with patch.object(PhysicalAndroidDevice, "default_adb_paths", [str(adb_path)]):
+                device = create_device(setting, Runtime())
+                self.assertEqual(device.adb_path, adb_path)
+                self.assertTrue(device.validate_adb_path())
+
+    def test_infer_device_type_supports_legacy_bluestacks_paths(self):
+        setting = Setting()
+        setting.DEVICE_TYPE = None
+        setting.EMU_PATH = r"C:\BlueStacks\HD-Player.exe"
+        self.assertEqual(infer_device_type(setting), "bluestacks")
+
+    def test_infer_device_type_supports_gpg_dev_paths(self):
+        for path in [
+            r"C:\Program Files\Google\Play Games Developer Emulator",
+            r"C:\Program Files\Google\Play Games Developer Emulator\current\emulator",
+            r"C:\Program Files\Google\Play Games Developer Emulator\current\emulator\crosvm.exe",
+            r"C:\Program Files\Google\Play Games Developer Emulator\current\service\Service.exe",
+        ]:
+            with self.subTest(path=path):
+                setting = Setting()
+                setting.DEVICE_TYPE = None
+                setting.EMU_PATH = path
+                self.assertEqual(infer_device_type(setting), "gpg_dev")
+
+    def test_unknown_device_type_falls_back_to_mumu(self):
+        self.assertIsInstance(self.make_device("unknown", r"C:\MuMu\shell"), MuMuEmulatorDevice)
+
+    def test_validate_adb_path_windows_paths_do_not_raise_on_non_windows(self):
+        devices = [
+            self.make_device("mumu", r"C:\__WVD_MISSING__\MuMuPlayer"),
+            self.make_device("bluestacks", r"C:\__WVD_MISSING__\BlueStacks_nxt"),
+            self.make_device("gpg_dev", r"C:\__WVD_MISSING__\Play Games Developer Emulator"),
+            self.make_device("physical", adb_path=r"C:\Android\platform-tools\adb.exe"),
+        ]
+        for device in devices:
+            with self.subTest(device=device.device_type):
+                self.assertFalse(device.validate_adb_path())
+
+    def test_start_emulator_missing_windows_path_returns_false(self):
+        devices = [
+            self.make_device("mumu", r"C:\__WVD_MISSING__\MuMuPlayer"),
+            self.make_device("bluestacks", r"C:\__WVD_MISSING__\BlueStacks_nxt"),
+            self.make_device("gpg_dev", r"C:\__WVD_MISSING__\Play Games Developer Emulator"),
+        ]
+        for device in devices:
+            with self.subTest(device=device.device_type):
+                self.assertFalse(device.start_emulator())
+
+    def test_default_install_root_can_satisfy_validate_adb_path(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            shell = root / "nx_device" / "12.0" / "shell"
+            shell.mkdir(parents=True)
+            (shell / "adb.exe").touch()
+            setting = Setting()
+            setting.DEVICE_TYPE = "mumu"
+            setting.EMU_PATH = ""
+            runtime = Runtime()
+            with patch.object(MuMuEmulatorDevice, "default_install_roots", [str(root)]):
+                device = create_device(setting, runtime)
+                self.assertEqual(device.install_root, root)
+                self.assertTrue(device.validate_adb_path())
+
+    def test_connect_does_not_kill_emulator_immediately_after_start(self):
+        class FakeResult:
+            stdout = "List of devices attached\n"
+            stderr = ""
+            returncode = 0
+
+        class FakeEmulator(EmulatorDevice):
+            device_type = "fake"
+            process_names = ["fake.exe"]
+            default_install_roots = ["/fake"]
+
+            @property
+            def adb_path(self):
+                return Path("adb")
+
+            def __init__(self, setting, runtime_context):
+                super().__init__(setting, runtime_context)
+                self.started = 0
+                self.killed = 0
+
+            def is_running(self):
+                return False
+
+            def start_emulator(self):
+                self.started += 1
+                return True
+
+            def kill_emulator(self):
+                self.killed += 1
+
+            def _run_adb(self, *args, timeout=10):
+                return FakeResult()
+
+            def _create_ppadb_device(self):
+                return None
+
+        setting = Setting()
+        setting.EMU_PATH = "/fake"
+        setting.ADB_ADRESS = "127.0.0.1:16384"
+        device = FakeEmulator(setting, Runtime())
+        with patch("device.time.sleep", return_value=None):
+            self.assertIsNone(device.connect())
+        self.assertGreater(device.started, 0)
+        self.assertEqual(device.killed, 0)
+
+    def test_adb_device_state_requires_exact_device_row(self):
+        device = self.make_device("gpg_dev", r"C:\GPG")
+        device.setting.ADB_ADRESS = "localhost:6520"
+        self.assertEqual(
+            device._adb_device_state("List of devices attached\nlocalhost:6520\tdevice\n"),
+            "device",
+        )
+        self.assertEqual(
+            device._adb_device_state("List of devices attached\nlocalhost:6520\toffline\n"),
+            "offline",
+        )
+        self.assertIsNone(device._adb_device_state("List of devices attached\nlocalhost:6521\tdevice\n"))
+
+    def test_connect_skips_tcp_connect_when_device_is_already_ready(self):
+        class FakeResult:
+            stderr = ""
+            returncode = 0
+
+            def __init__(self, stdout):
+                self.stdout = stdout
+
+        class FakeGpg(GooglePlayGamesDevEmulatorDevice):
+            def __init__(self, setting, runtime_context):
+                super().__init__(setting, runtime_context)
+                self.calls = []
+
+            @property
+            def adb_path(self):
+                return Path("adb")
+
+            def _run_adb(self, *args, timeout=10):
+                self.calls.append(args)
+                return FakeResult("List of devices attached\nlocalhost:6520\tdevice\n")
+
+            def _create_ppadb_device(self):
+                return object()
+
+            def after_connect(self):
+                pass
+
+        setting = Setting()
+        setting.DEVICE_TYPE = "gpg_dev"
+        setting.ADB_ADRESS = "localhost:6520"
+        device = FakeGpg(setting, Runtime())
+        self.assertIsNotNone(device.connect())
+        self.assertNotIn(("connect", "localhost:6520"), device.calls)
+
+    def test_gpg_connect_failure_does_not_kill_emulator_while_booting(self):
+        class FakeResult:
+            stdout = "List of devices attached\n"
+            stderr = ""
+            returncode = 0
+
+        class FakeGpg(GooglePlayGamesDevEmulatorDevice):
+            def __init__(self, setting, runtime_context):
+                super().__init__(setting, runtime_context)
+                self.killed = 0
+
+            @property
+            def adb_path(self):
+                return Path("adb")
+
+            def _run_adb(self, *args, timeout=10):
+                return FakeResult()
+
+            def is_running(self):
+                return True
+
+            def kill_emulator(self):
+                self.killed += 1
+
+        setting = Setting()
+        setting.DEVICE_TYPE = "gpg_dev"
+        setting.ADB_ADRESS = "localhost:6520"
+        device = FakeGpg(setting, Runtime())
+        with patch("device.time.sleep", return_value=None):
+            self.assertIsNone(device.connect())
+        self.assertEqual(device.killed, 0)
+
+    def test_connect_rejects_devices_output_when_adb_exit_code_fails(self):
+        class FakeResult:
+            stdout = "List of devices attached\nphysical-serial\tdevice\n"
+            stderr = "adb failed"
+            returncode = 1
+
+        class FakePhysical(PhysicalAndroidDevice):
+            def __init__(self, setting, runtime_context):
+                super().__init__(setting, runtime_context)
+                self.created_device = False
+
+            @property
+            def adb_path(self):
+                return Path("adb")
+
+            def _run_adb(self, *args, timeout=10):
+                return FakeResult()
+
+            def _create_ppadb_device(self):
+                self.created_device = True
+                return object()
+
+        setting = Setting()
+        setting.DEVICE_TYPE = "physical"
+        setting.ADB_ADRESS = "physical-serial"
+        setting.ADB_PATH = "adb"
+        device = FakePhysical(setting, Runtime())
+        with patch("device.time.sleep", return_value=None):
+            self.assertIsNone(device.connect())
+        self.assertFalse(device.created_device)
+
+    def test_gpg_restart_target_kills_service_then_starts_bootstrapper(self):
+        device = self.make_device("gpg_dev", r"C:\Program Files\Google\Play Games Developer Emulator")
+        with patch("device.time.sleep", return_value=None), patch.object(device, "kill_emulator") as kill_emulator, patch.object(
+            device, "start_emulator", return_value=True
+        ) as start_emulator, patch.object(device, "_run_adb") as run_adb:
+            self.assertTrue(device.restart_target())
+
+        kill_emulator.assert_called_once_with()
+        start_emulator.assert_called_once_with()
+        run_adb.assert_not_called()
+
+    def test_gpg_detect_running_pids_filters_service_by_install_root(self):
+        device = self.make_device("gpg_dev", r"C:\Program Files\Google\Play Games Developer Emulator")
+
+        class FakeResult:
+            stdout = "1234\nnot-a-pid\n"
+            stderr = ""
+
+        with patch("device.os.name", "nt"), patch("device.subprocess.run", return_value=FakeResult()) as run:
+            self.assertEqual(device.detect_running_pids(), [1234])
+
+        command = run.call_args.args[0]
+        self.assertEqual(command[:3], ["powershell", "-NoProfile", "-Command"])
+        self.assertIn("Name = 'Service.exe'", command[3])
+        self.assertIn("ExecutablePath.StartsWith", command[3])
+        self.assertIn("C:\\Program Files\\Google\\Play Games Developer Emulator\\", command[3])
+
+    def test_gpg_kill_emulator_uses_filtered_pids_not_service_name(self):
+        device = self.make_device("gpg_dev", r"C:\Program Files\Google\Play Games Developer Emulator")
+
+        class FakeResult:
+            stdout = ""
+            stderr = ""
+            returncode = 0
+
+        with patch.object(device, "detect_running_pids", return_value=[1234, 5678]), patch(
+            "device.subprocess.run", return_value=FakeResult()
+        ) as run, patch("device.time.sleep", return_value=None):
+            device.kill_emulator()
+
+        commands = [call.args[0] for call in run.call_args_list]
+        self.assertEqual(
+            commands,
+            [
+                ["taskkill", "/F", "/PID", "1234"],
+                ["taskkill", "/F", "/PID", "5678"],
+            ],
+        )
+        self.assertFalse(any("/IM" in command for command in commands))
+
+    def test_gpg_emulator_path_points_to_service_process(self):
+        root = PureWindowsPath(r"C:\Program Files\Google\Play Games Developer Emulator")
+        device = self.make_device("gpg_dev", str(root))
+        self.assertEqual(device.emu_path, root / "current" / "service" / "Service.exe")
+
+    def test_after_connect_sets_display_for_gpg_and_physical(self):
+        for device_type in ["gpg_dev", "physical"]:
+            with self.subTest(device_type=device_type):
+                calls = []
+
+                class FakeResult:
+                    stdout = ""
+                    stderr = ""
+                    returncode = 0
+
+                device = self.make_device(device_type, r"C:\GPG", r"C:\Android\platform-tools\adb.exe")
+                device.setting.ADB_ADRESS = "device-serial"
+                with patch.object(device, "_run_adb", side_effect=lambda *args, **kwargs: calls.append(args) or FakeResult()):
+                    device.after_connect()
+                self.assertEqual(
+                    calls,
+                    [
+                        ("-s", "device-serial", "shell", "wm", "size", "900x1600"),
+                        ("-s", "device-serial", "shell", "wm", "density", "240"),
+                    ],
+                )
+
+    def test_restore_display_resets_physical_device_display(self):
+        calls = []
+
+        class FakeResult:
+            stdout = ""
+            stderr = ""
+            returncode = 0
+
+        device = self.make_device("physical", adb_path=r"C:\Android\platform-tools\adb.exe")
+        device.setting.ADB_ADRESS = "physical-serial"
+        with patch.object(device, "_run_adb", side_effect=lambda *args, **kwargs: calls.append(args) or FakeResult()):
+            self.assertTrue(device.restore_display())
+
+        self.assertEqual(
+            calls,
+            [
+                ("-s", "physical-serial", "shell", "wm", "size", "reset"),
+                ("-s", "physical-serial", "shell", "wm", "density", "reset"),
+            ],
+        )
+
+    def test_restore_display_is_noop_for_emulators(self):
+        device = self.make_device("gpg_dev", r"C:\GPG")
+        with patch.object(device, "_run_adb") as run_adb:
+            self.assertTrue(device.restore_display())
+        run_adb.assert_not_called()
+
+    def test_cleanup_after_stop_closes_game_then_resets_physical_display(self):
+        adb_calls = []
+        shell_calls = []
+
+        class FakeResult:
+            stdout = ""
+            stderr = ""
+            returncode = 0
+
+        class FakeAdbDevice:
+            serial = "physical-serial"
+
+            def shell(self, cmd, timeout=5):
+                shell_calls.append(cmd)
+                return ""
+
+        device = self.make_device("physical", adb_path=r"C:\Android\platform-tools\adb.exe")
+        device.setting.ADB_ADRESS = "physical-serial"
+        device.setting._ADBDEVICE = FakeAdbDevice()
+        with patch.object(device, "_run_adb", side_effect=lambda *args, **kwargs: adb_calls.append(args) or FakeResult()):
+            self.assertTrue(device.cleanup_after_stop())
+
+        self.assertEqual(shell_calls, ["am force-stop jp.co.drecom.wizardry.daphne"])
+        self.assertEqual(
+            adb_calls,
+            [
+                ("-s", "physical-serial", "shell", "wm", "size", "reset"),
+                ("-s", "physical-serial", "shell", "wm", "density", "reset"),
+            ],
+        )
+
+    def test_cleanup_after_stop_resets_display_if_close_game_fails(self):
+        adb_calls = []
+
+        class FakeResult:
+            stdout = ""
+            stderr = ""
+            returncode = 0
+
+        class FakeAdbDevice:
+            serial = "physical-serial"
+
+            def shell(self, cmd, timeout=5):
+                raise RuntimeError("force-stop failed")
+
+        device = self.make_device("physical", adb_path=r"C:\Android\platform-tools\adb.exe")
+        device.setting.ADB_ADRESS = "physical-serial"
+        device.setting._ADBDEVICE = FakeAdbDevice()
+        with patch.object(device, "_run_adb", side_effect=lambda *args, **kwargs: adb_calls.append(args) or FakeResult()):
+            self.assertFalse(device.cleanup_after_stop())
+
+        self.assertEqual(
+            adb_calls,
+            [
+                ("-s", "physical-serial", "shell", "wm", "size", "reset"),
+                ("-s", "physical-serial", "shell", "wm", "density", "reset"),
+            ],
+        )
+
+    def test_cleanup_after_stop_is_noop_for_emulators(self):
+        device = self.make_device("gpg_dev", r"C:\GPG")
+        with patch.object(device, "_run_adb") as run_adb:
+            self.assertTrue(device.cleanup_after_stop())
+        run_adb.assert_not_called()
+
+    def test_restart_game_requires_connected_device(self):
+        device = self.make_device("physical", adb_path=r"C:\Android\platform-tools\adb.exe")
+        with self.assertRaises(RuntimeError):
+            device.restart_game()
+
+    def test_restart_game_skips_start_when_activity_unresolved(self):
+        calls = []
+
+        class FakeAdbDevice:
+            serial = "device"
+
+            def shell(self, cmd, timeout=5):
+                calls.append(cmd)
+                if "resolve-activity" in cmd:
+                    return "No activity found"
+                return ""
+
+        device = self.make_device("physical", adb_path=r"C:\Android\platform-tools\adb.exe")
+        device.setting._ADBDEVICE = FakeAdbDevice()
+        with patch.object(device, "clear_logcat", return_value=None):
+            self.assertFalse(device.restart_game())
+        self.assertNotIn("am force-stop jp.co.drecom.wizardry.daphne", calls)
+
+    def test_restart_game_clears_all_logcat_buffers_before_start(self):
+        adb_calls = []
+        shell_calls = []
+
+        class FakeResult:
+            stdout = ""
+            stderr = ""
+            returncode = 0
+
+        class FakeAdbDevice:
+            serial = "physical-serial"
+
+            def shell(self, cmd, timeout=5):
+                shell_calls.append(cmd)
+                if "resolve-activity" in cmd:
+                    return "jp.co.drecom.wizardry.daphne/.MainActivity"
+                return ""
+
+        device = self.make_device("physical", adb_path=r"C:\Android\platform-tools\adb.exe")
+        device.setting.ADB_ADRESS = "physical-serial"
+        device.setting._ADBDEVICE = FakeAdbDevice()
+        with patch.object(device, "_run_adb", side_effect=lambda *args, **kwargs: adb_calls.append(args) or FakeResult()):
+            self.assertTrue(device.restart_game())
+
+        self.assertEqual(adb_calls[0], ("-s", "physical-serial", "shell", "logcat", "-b", "all", "-c"))
+        self.assertIn("am force-stop jp.co.drecom.wizardry.daphne", shell_calls)
+
+    def test_graphics_api_crash_scan_reads_all_logcat_buffers_in_python(self):
+        calls = []
+
+        class FakeResult:
+            stderr = ""
+            returncode = 0
+            stdout = "\n".join(
+                [
+                    "normal line",
+                    "E Unity: Unable to initialize graphics API Vulkan",
+                ]
+            )
+
+        device = self.make_device("physical", adb_path=r"C:\Android\platform-tools\adb.exe")
+        device.setting.ADB_ADRESS = "physical-serial"
+        with patch.object(device, "_run_adb", side_effect=lambda *args, **kwargs: calls.append(args) or FakeResult()):
+            logs = device.find_graphics_api_crash_log()
+
+        self.assertEqual(calls[0], ("-s", "physical-serial", "shell", "logcat", "-b", "all", "-d"))
+        self.assertIn("Unable to initialize graphics API", logs)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_device_integration.py
+++ b/tests/test_device_integration.py
@@ -1,0 +1,205 @@
+import os
+import subprocess
+import sys
+import time
+import unittest
+from datetime import datetime
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from device import create_device  # noqa: E402
+
+
+class DummySetting:
+    DEVICE_TYPE = os.environ.get("WVD_TEST_DEVICE_TYPE", "mumu")
+    EMU_PATH = os.environ.get("WVD_TEST_EMU_PATH")
+    EMU_INDEX = int(os.environ.get("WVD_TEST_EMU_INDEX", "0"))
+    ADB_ADRESS = os.environ.get("WVD_TEST_ADB_ADDRESS", "127.0.0.1:16384")
+    ADB_PATH = os.environ.get("WVD_TEST_ADB_PATH", "")
+    _ADBDEVICE = None
+
+
+class DummyRuntime:
+    _RUNNING_EMU_PID = None
+
+
+def adb_path_for(setting):
+    if setting.ADB_PATH:
+        return Path(setting.ADB_PATH)
+    if setting.DEVICE_TYPE == "mumu" and setting.EMU_PATH:
+        path = Path(setting.EMU_PATH)
+        if path.name.lower() in ["adb.exe", "mumuplayer.exe", "mumunxdevice.exe"]:
+            path = path.parent
+        if path.name.lower() == "shell":
+            return path / "adb.exe"
+        return path / "nx_device" / "12.0" / "shell" / "adb.exe"
+    if setting.DEVICE_TYPE == "bluestacks" and setting.EMU_PATH:
+        path = Path(setting.EMU_PATH)
+        if path.name.lower() in ["hd-adb.exe", "hd-player.exe"]:
+            path = path.parent
+        return path / "HD-Adb.exe"
+    if setting.DEVICE_TYPE == "gpg_dev" and setting.EMU_PATH:
+        path = Path(setting.EMU_PATH)
+        if path.name.lower() in ["adb.exe", "crosvm.exe", "service.exe"]:
+            path = path.parent
+        if path.name.lower() == "service":
+            path = path.parent.parent / "emulator"
+        if path.name.lower() == "emulator":
+            return path / "adb.exe"
+        return path / "current" / "emulator" / "adb.exe"
+    return None
+
+
+RUN_DEVICE_TESTS = (
+    os.environ.get("WVD_RUN_DEVICE_TESTS") == "1"
+    or os.environ.get("WVD_RUN_EMULATOR_TESTS") == "1"
+)
+RUN_EMULATOR_RESTART_TESTS = os.environ.get("WVD_RUN_EMULATOR_RESTART_TESTS") == "1"
+
+
+@unittest.skipUnless(
+    RUN_DEVICE_TESTS,
+    "set WVD_RUN_DEVICE_TESTS=1 to run real device integration tests",
+)
+class RealDeviceIntegrationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.setting = DummySetting()
+        cls.runtime = DummyRuntime()
+        cls.adb_path = adb_path_for(cls.setting)
+        if cls.adb_path is None:
+            raise unittest.SkipTest("WVD_TEST_ADB_PATH or WVD_TEST_EMU_PATH is required")
+        if not cls.adb_path.exists():
+            raise unittest.SkipTest(f"ADB executable does not exist: {cls.adb_path}")
+        cls.device = create_device(cls.setting, cls.runtime)
+        cls.package_name = os.environ.get("WVD_TEST_PACKAGE", "jp.co.drecom.wizardry.daphne")
+
+    def raw_adb(self, *args, timeout=10):
+        return subprocess.run(
+            [str(self.adb_path), *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+
+    def assert_target_in_adb_devices(self):
+        result = self.raw_adb("devices")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(self.setting.ADB_ADRESS, result.stdout)
+        self.assertIn("device", result.stdout)
+
+    def test_adb_devices_contains_target(self):
+        if ":" in self.setting.ADB_ADRESS:
+            self.raw_adb("connect", self.setting.ADB_ADRESS)
+        self.assert_target_in_adb_devices()
+
+    def test_device_connect_and_shell(self):
+        adb_device = self.device.connect()
+        self.assertIsNotNone(adb_device)
+        self.assertEqual(adb_device.serial, self.setting.ADB_ADRESS)
+        self.assertTrue(self.device.shell("echo WVD_TEST").strip().endswith("WVD_TEST"))
+
+    def test_screencap_returns_parseable_header(self):
+        self.device.connect()
+        width, height, fmt = self.assert_screencap_parseable()
+        self.assertGreater(width, 0)
+        self.assertGreater(height, 0)
+        self.assertIn(fmt, [1, 2, 3, 4])
+
+    def assert_screencap_parseable(self):
+        result = self.device.screencap()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertGreaterEqual(len(result.stdout), 12)
+        width = int.from_bytes(result.stdout[0:4], "little")
+        height = int.from_bytes(result.stdout[4:8], "little")
+        fmt = int.from_bytes(result.stdout[8:12], "little")
+        return width, height, fmt
+
+    def save_png_screenshot(self, name_prefix="integration_screenshot"):
+        artifact_dir = ROOT / "logs" / "integration"
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        output_path = artifact_dir / f"{name_prefix}_{timestamp}.png"
+
+        result = subprocess.run(
+            [str(self.adb_path), "-s", self.setting.ADB_ADRESS, "exec-out", "screencap", "-p"],
+            capture_output=True,
+            timeout=10,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(result.stdout.startswith(b"\x89PNG\r\n\x1a\n"))
+        output_path.write_bytes(result.stdout)
+        self.assertGreater(output_path.stat().st_size, 1024)
+        return output_path
+
+    def wait_for_package_pid(self, timeout=30):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            pid_output = self.device.shell(f"pidof {self.package_name}").strip()
+            if pid_output:
+                self.assertTrue(pid_output.split()[0].isdigit())
+                return pid_output
+            time.sleep(1)
+        self.fail(f"package did not start within {timeout}s: {self.package_name}")
+
+    def test_game_package_resolves_when_installed(self):
+        self.device.connect()
+        result = self.device.shell(f"cmd package resolve-activity --brief {self.package_name}").strip()
+        self.assertNotIn("No activity found", result)
+        self.assertIn("/", result)
+
+    def test_restart_game_on_real_device(self):
+        self.device.connect()
+        self.assertTrue(self.device.restart_game(self.package_name))
+        self.wait_for_package_pid()
+
+    def test_force_restart_adb_reconnects_real_device(self):
+        adb_device = self.device.connect(force_restart_adb=True)
+        self.assertIsNotNone(adb_device)
+        self.assertEqual(adb_device.serial, self.setting.ADB_ADRESS)
+        self.assert_target_in_adb_devices()
+
+    @unittest.skipUnless(
+        RUN_EMULATOR_RESTART_TESTS,
+        "set WVD_RUN_EMULATOR_RESTART_TESTS=1 to kill and restart the emulator process",
+    )
+    def test_force_restart_emulator_reconnects_real_device(self):
+        if self.setting.DEVICE_TYPE == "physical":
+            self.skipTest("physical device cannot restart emulator process")
+
+        adb_device = self.device.connect(force_restart_emu=True)
+        self.assertIsNotNone(adb_device)
+        self.assertEqual(adb_device.serial, self.setting.ADB_ADRESS)
+        self.assert_target_in_adb_devices()
+
+    @unittest.skipUnless(
+        RUN_EMULATOR_RESTART_TESTS,
+        "set WVD_RUN_EMULATOR_RESTART_TESTS=1 to kill and restart the emulator process",
+    )
+    def test_restart_emulator_start_game_and_screenshot(self):
+        if self.setting.DEVICE_TYPE == "physical":
+            self.skipTest("physical device cannot restart emulator process")
+
+        adb_device = self.device.connect(force_restart_emu=True)
+        self.assertIsNotNone(adb_device)
+        self.assertEqual(adb_device.serial, self.setting.ADB_ADRESS)
+
+        self.assertTrue(self.device.restart_game(self.package_name))
+        self.wait_for_package_pid()
+        time.sleep(10)
+
+        width, height, fmt = self.assert_screencap_parseable()
+        self.assertGreaterEqual(width, 100)
+        self.assertGreaterEqual(height, 100)
+        self.assertIn(fmt, [1, 2, 3, 4])
+        screenshot_path = self.save_png_screenshot("restart_emulator_start_game")
+        print(f"saved screenshot: {screenshot_path}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_utils_logging.py
+++ b/tests/test_utils_logging.py
@@ -1,0 +1,63 @@
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import utils  # noqa: E402
+
+
+class FakeHandler:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+class FakeQueueListener:
+    instances = []
+
+    def __init__(self, queue, handler):
+        self.queue = queue
+        self.handlers = [handler]
+        self.started = False
+        self.stopped = False
+        FakeQueueListener.instances.append(self)
+
+    def start(self):
+        self.started = True
+
+    def stop(self):
+        self.stopped = True
+
+
+class LoggingSetupTests(unittest.TestCase):
+    def tearDown(self):
+        utils.queue_listener = None
+        utils._log_listener_started = False
+        FakeQueueListener.instances.clear()
+
+    def test_log_listener_is_created_lazily_and_closes_handler(self):
+        handler = FakeHandler()
+
+        with patch.object(utils, "setup_file_handler", return_value=handler), patch.object(
+            utils.logging.handlers, "QueueListener", FakeQueueListener
+        ):
+            self.assertIsNone(utils.queue_listener)
+            utils.StartLogListener()
+            self.assertTrue(FakeQueueListener.instances[0].started)
+
+            utils.StopLogListener()
+            self.assertTrue(FakeQueueListener.instances[0].stopped)
+            self.assertTrue(handler.closed)
+            self.assertIsNone(utils.queue_listener)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要

本 PR 将原本散落在 `script.py` 的 ADB、模拟器启动/关闭、游戏重启与停止后清理逻辑整理到新的 `src/device.py`，并新增多设备类型支持。

新的 `Device` / `EmulatorDevice` 结构可以通过继承扩展，后续要新增模拟器支持时，只需要新增对应子类并注册到设备 registry。

本次也新增 Google Play 游戏电脑版开发人员模拟器（Google Play Games Developer Emulator，程式内简称 `gpg_dev`）支持。

主要支持：

- MuMu 模拟器
- Google Play 游戏电脑版开发人员模拟器
- 实体 Android 设备
- BlueStacks Legacy，沿用旧程式逻辑迁移，尚未做真实环境测试

## 主要变更

- 新增可继承的 `Device` / `EmulatorDevice` 设备抽象，并通过 `create_device()` 根据 `DEVICE_TYPE` 建立设备实例。
- GUI 设备配置改为按设备类型显示必要配置项，例如 ADB 工具、ADB 地址和多开编号。
- 支持 Google Play Games Developer Emulator 的连接、启动与重启流程，并限制操作范围，避免影响其他同名系统进程。
- 停止任务和关闭程序时，若已建立设备实例，会尝试执行设备层的停止后清理；目前主要用于实体设备关闭游戏并恢复分辨率/DPI。
- 旅店无限睡觉任务增加 `_FORCESTOPING` 检查，修正原先停止任务后仍可能继续循环的问题。
- 游戏重启前清理 logcat，并在 Python 内扫描图形 API 崩溃日志，避免依赖 shell pipe/grep。
- 日志监听改为惰性启动，并补上停止时 handler 关闭逻辑，避免重复 listener/handler。
- 新增设备路径、连接、重启、logcat、停止清理等单元测试。

## 修复点

- ADB 初始连接失败时，不再无条件调用 `restart_game()`，避免 `_ADBDEVICE` 为空时抛出 `RuntimeError`。
- import `utils.py` 时不再立即建立空白 log 文件；log file handler 改为 `StartLogListener()` 时才建立。
- Ctrl+C、关闭视窗、停止任务时统一走 `force_shutdown()` / `cleanup_after_stop()`，降低程序或 UI 卡在运行/停止状态的概率。
- 修正旅店无限睡觉任务原先无法可靠停止的问题；其他任务是否有类似停止延迟尚未逐一确认。
- 重启游戏前会清理 logcat，避免实体设备上残留的旧 graphics API crash 记录造成误判并反复重启。
- ADB 命令现在会检查 return code，避免命令失败时仍把 stdout 当成成功连接结果解析。

## 测试

- `python3 -m py_compile src/device.py src/script.py src/gui.py src/main.py src/utils.py tests/test_device.py tests/test_device_integration.py tests/test_utils_logging.py`
  - 通过；保留既有 `spellskill\...` invalid escape warning。

- Windows 测试主机 `win11`，目录 `C:\Users\kuaz\Downloads\wvd`：
  - `.venv\Scripts\python.exe -m unittest discover -s tests -v`
  - 结果：`Ran 44 tests ... OK (skipped=8)`

- 已通过 `tests/test_device_integration.py` 测试会实际关闭/重启设备或模拟器的流程，并在以下设备上跑过王女要钱任务 `G7000`：
  - 实体 Android 设备
  - MuMu 模拟器
  - Google Play Games Developer Emulator

- BlueStacks Legacy 未做真实环境测试；目前是从旧实现迁移到新的 Device 抽象，保留原有行为。

## 自我检查

- [x] 设备连接逻辑已从 `script.py` 移到 `src/device.py`，任务流程改用 `create_device()`。
- [x] GPG 重启流程会限制在对应安装目录范围内，避免影响其他同名系统进程。
- [x] ADB 未连接时不会在任务启动阶段直接调用 `restart_game()`。
- [x] 停止任务与关闭程序时会触发设备层清理入口；实体设备会关闭游戏并恢复分辨率/DPI。
- [x] 旅店无限睡觉任务已补 `_FORCESTOPING` 检查。
- [x] 日志 listener 可重复启动/停止，不会重复添加相同 queue handler。
- [x] logcat 崩溃检测不再依赖 shell pipe/grep。
- [ ] BlueStacks Legacy 尚未做真实环境测试，仅迁移旧逻辑。
- [ ] 其他任务是否存在类似停止延迟尚未逐一确认。
- [ ] Python 3.14 会提示既有 `spellskill\...` 路径字符串存在 invalid escape warning；此问题不是本 PR 新增，尚未在本 PR 处理。

## 给维护者的说明

这次 GUI 会显示更多设备相关配置，例如模拟器路径、ADB 工具与清理进程等信息。原本这些推导逻辑主要藏在程式内，如果这不符合既有 UI 设计方向，可以再调整显示方式，或把部分进阶信息隐藏起来。

## 手动验证说明

已验证实体设备、MuMu、GPG 的真实连接/重启相关流程，包括会实际关闭或重启目标设备/模拟器的流程，并在三种设备上跑过王女要钱任务 `G7000`。

GPG 模拟器重启测试建议在互动式 Windows 桌面执行；SSH session 可能导致 `Bootstrapper.exe` 启动在不同 session，影响 ADB 恢复。

BlueStacks Legacy 未做真实环境测试，本次仅将旧程式既有逻辑搬迁到新的 `Device` 抽象中，后续需要有 BlueStacks 环境再补实际验证。