### PR TITLE
延迟建立日志文件监听

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 # 临时文件
 __pycache__/
 src/__pycache__/
+.pycache
 
 # 本地测试文件
 log.txt

--- a/src/main.py
+++ b/src/main.py
@@ -175,7 +175,10 @@ def main():
     args = parse_args()
 
     controller = AppController(args.headless, args.config)
-    controller.mainloop()
+    try:
+        controller.mainloop()
+    finally:
+        StopLogListener()
 
 def HeadlessActive(config_path,msg_queue):
     RegisterConsoleHandler()

--- a/src/utils.py
+++ b/src/utils.py
@@ -7,10 +7,10 @@ import logging.handlers
 import sys
 import cv2
 import time
-import multiprocessing
 import numpy as np
 import glob
 import gettext
+import queue
 
 # 基础模块包括:
 # LOGGER. 将输入写入到logger.txt文件中.
@@ -50,11 +50,28 @@ def setup_file_handler():
     file_handler.setFormatter(file_formatter)
     return file_handler
 
-log_queue = multiprocessing.Queue(-1)
-queue_listener = logging.handlers.QueueListener(log_queue, setup_file_handler())
+log_queue = queue.Queue(-1)
+queue_listener = None
+_log_listener_started = False
 
 def StartLogListener():
+    global queue_listener, _log_listener_started
+    if _log_listener_started:
+        return
+    queue_listener = logging.handlers.QueueListener(log_queue, setup_file_handler())
     queue_listener.start()
+    _log_listener_started = True
+
+def StopLogListener():
+    global queue_listener, _log_listener_started
+    if not _log_listener_started:
+        return
+    listener = queue_listener
+    queue_listener.stop()
+    for handler in listener.handlers:
+        handler.close()
+    queue_listener = None
+    _log_listener_started = False
 #===========================================
 class LoggerStream:
     """自定义流，将输出重定向到logger"""
@@ -83,6 +100,10 @@ def RegisterQueueHandler():
     sys.stdout = LoggerStream(logger, logging.DEBUG)
     sys.stderr = LoggerStream(logger, logging.ERROR)
     
+    for handler in logger.handlers:
+        if isinstance(handler, logging.handlers.QueueHandler) and handler.queue is log_queue:
+            return
+
     # 创建QueueHandler并连接到全局队列
     queue_handler = logging.handlers.QueueHandler(log_queue)
     queue_handler.setLevel(logging.DEBUG)

--- a/tests/test_utils_logging.py
+++ b/tests/test_utils_logging.py
@@ -1,0 +1,63 @@
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import utils  # noqa: E402
+
+
+class FakeHandler:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+class FakeQueueListener:
+    instances = []
+
+    def __init__(self, queue, handler):
+        self.queue = queue
+        self.handlers = [handler]
+        self.started = False
+        self.stopped = False
+        FakeQueueListener.instances.append(self)
+
+    def start(self):
+        self.started = True
+
+    def stop(self):
+        self.stopped = True
+
+
+class LoggingSetupTests(unittest.TestCase):
+    def tearDown(self):
+        utils.queue_listener = None
+        utils._log_listener_started = False
+        FakeQueueListener.instances.clear()
+
+    def test_log_listener_is_created_lazily_and_closes_handler(self):
+        handler = FakeHandler()
+
+        with patch.object(utils, "setup_file_handler", return_value=handler), patch.object(
+            utils.logging.handlers, "QueueListener", FakeQueueListener
+        ):
+            self.assertIsNone(utils.queue_listener)
+            utils.StartLogListener()
+            self.assertTrue(FakeQueueListener.instances[0].started)
+
+            utils.StopLogListener()
+            self.assertTrue(FakeQueueListener.instances[0].stopped)
+            self.assertTrue(handler.closed)
+            self.assertIsNone(utils.queue_listener)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
避免 import utils 时立即建立空白 log 文件。

目前主要有三个地方会 import utils：

- src/gui.py:7
  - 启动 GUI 时会 import。 
  - main.py 一开始 from gui import *，所以一般开程式就会连带 import utils。 

- src/script.py:9
  - 任务/刷图逻辑会 import。 
  - gui.py 也会 import script 相关内容，所以 GUI 启动路径通常也会碰到。 

- src/auto_updater.py:13
  - 更新检查功能会 import。

StopLogListener 会停止 listener 并关闭 file handler，RegisterQueueHandler 会避免重复挂上同一个 queue handler。